### PR TITLE
fix:add_OBCT_sec2cycle #32

### DIFF
--- a/src/src_user/Settings/Modes/Transitions/sl_fine_three_axis.c
+++ b/src/src_user/Settings/Modes/Transitions/sl_fine_three_axis.c
@@ -43,7 +43,7 @@ void BCL_load_rough_three_axis_rw_to_fine_three_axis(void)
   timing_sec += 35;
 
   // モード遷移完了
-  BCL_tool_register_cmd(timing_sec, Cmd_CODE_MM_FINISH_TRANSITION);
+  BCL_tool_register_cmd(OBCT_sec2cycle(timing_sec), Cmd_CODE_MM_FINISH_TRANSITION);
 
   // 自動モード遷移ON
   timing_sec += (5 * 60);


### PR DESCRIPTION
## 概要
精三軸移行判定のタイミングの修正

## Issue
- 関連する issue
#32 

## 詳細
モード遷移完了判定の第一引数をtiming_secからOBCT_sec2cycle(timing_sec)に変更

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 図や表で記述する

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

## 注意
- 6U AOCS team Projects への紐付けを行うこと
- Assignees を自分に設定すること
- Reviewers を設定すること
- `priority` ラベルや`major/minor/patch update`ラベルを付けること
