### PR TITLE
Bdotでの磁場情報を計測値から推定値に変更

### DIFF
--- a/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/bdot.c
+++ b/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/bdot.c
@@ -143,10 +143,10 @@ AOCS_ERROR APP_BDOT_calculate_mag_vec_time_derivative_(void)
   if (bdot->time_derivative_variables.num_of_mag_observation == 0)
   {
     // 磁気センサの観測が開始していない場合，磁場ベクトルが0となっているので，その場合はすぐにリターンする
-    if (VECTOR3_norm(aocs_manager->mag_vec_obs_body_nT) < MATH_CONST_NORMAL_CHECK_THRESHOLD) return AOCS_ERROR_OTHERS;
+    if (VECTOR3_norm(aocs_manager->mag_vec_est_body_nT) < MATH_CONST_NORMAL_CHECK_THRESHOLD) return AOCS_ERROR_OTHERS;
 
     bdot_.time_derivative_variables.previous_obc_time = TMGR_get_master_clock();
-    VECTOR3_copy(bdot_.time_derivative_variables.mag_vec_before_nT, aocs_manager->mag_vec_obs_body_nT);
+    VECTOR3_copy(bdot_.time_derivative_variables.mag_vec_before_nT, aocs_manager->mag_vec_est_body_nT);
 
     // 1回目の観測が終了した段階では，磁場ベクトルの微分はまだ計算できないので，エラーを出してリターンする．
     bdot_.time_derivative_variables.num_of_mag_observation = 1;
@@ -155,7 +155,7 @@ AOCS_ERROR APP_BDOT_calculate_mag_vec_time_derivative_(void)
   else // bdot->time_derivative_variables.num_of_mag_observation == 1
   {
     bdot_.time_derivative_variables.current_obc_time = TMGR_get_master_clock();
-    VECTOR3_copy(bdot_.time_derivative_variables.mag_vec_after_nT, aocs_manager->mag_vec_obs_body_nT);
+    VECTOR3_copy(bdot_.time_derivative_variables.mag_vec_after_nT, aocs_manager->mag_vec_est_body_nT);
 
     // 時間微分のインターバルが一定以下の場合は，姿勢レートの変化が不十分とみなし，磁場の時間微分を計算しない
     if (OBCT_diff_in_msec(&(bdot->time_derivative_variables.previous_obc_time), &(bdot->time_derivative_variables.current_obc_time))


### PR DESCRIPTION
## 概要
Bdotでの磁場情報を計測値から推定値に変更

## Issue
- 関連する issue
- #34 

## 詳細
詳しく

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 条件
  - 自動モード遷移をOFFにしてBdotモード
  - 各軸初期角速度を0.01rad/sに設定
- 結果
  - obsを使った場合よりestを使った場合の方が、角速度がより滑らかに推移していることが確認できる。

![obs](https://github.com/ut-issl/c2a-aobc/assets/82629762/dd34a797-7030-471b-8038-e3084ba55358)
![est](https://github.com/ut-issl/c2a-aobc/assets/82629762/c88c1d5f-d58e-406c-a359-6f29f8e131dc)


## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

<!--
## 注意
- 6U AOCS team Projects への紐付けを行うこと
- Assignees を自分に設定すること
- Reviewers を設定すること
- `priority` ラベルや`major/minor/patch update`ラベルを付けること
-->
