### PR TITLE
Fix vMicro to add satellite parameters

### DIFF
--- a/c2a_aobc.filters
+++ b/c2a_aobc.filters
@@ -452,12 +452,6 @@
     <ClCompile Include="src\src_user\Settings\Modes\mode_definitions.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\src_user\Settings\SatelliteParameters\Sample\orbit_parameters.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="src\src_user\Settings\SatelliteParameters\Sample\structure_parameters.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="src\src_core\c2a_core_main.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
## 概要
Fix vMicro to add satellite parameters

## Issue
NA

## 詳細
vMicroビルドチェック前にマージしてしまったことの緊急対応

## 検証結果
### ビルドチェック (どちらもチェック)
- [ ] SILSでのビルドチェックに通った(CIで確認) -> 関係なし
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
NA

## 影響範囲
NA

## 補足
NA

## 注意
NA