### PR TITLE
Fix cache setting for build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/cache@v3
         with:
           key: extlib-${{ runner.os }}-${{ hashFiles('./s2e-aobc/s2e-core/ExtLibraries/**') }}
-          path: ExtLibraries
+          path: ./s2e-aobc/s2e-core/ExtLibraries
 
       - name: build extlib
         if: steps.cache-extlib.outputs.cache-hit != 'true'
@@ -66,7 +66,7 @@ jobs:
         working-directory: ./s2e-aobc/s2e-core/ExtLibraries
         run: |
           cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug"
-          cmake --build .
+          cmake --build . --clean-first
 
       - name: install extlib
         if: steps.cache-extlib.outputs.cache-hit != 'true'
@@ -95,7 +95,7 @@ jobs:
         run: |
           cl.exe
           cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_CONFIGURATION_TYPES:STRING="Debug" -DFLIGHT_SW_DIR=../../../ -DC2A_NAME=c2a-aobc -DUSE_C2A=ON
-          cmake --build .
+          cmake --build . --clean-first
 
   build_c2a_with_s2e_linux:
     name: Build C2A with S2E on Linux
@@ -130,6 +130,7 @@ jobs:
           read -r -a COMPILER <<< "$COMPILER"
           echo "CC=${COMPILER[0]}" >> "$GITHUB_OUTPUT"
           echo "CXX=${COMPILER[1]}" >> "$GITHUB_OUTPUT"
+
       - name: install deps
         run: |
           # FIXME: temporary install gcc-11 in ubuntu:focal
@@ -143,29 +144,33 @@ jobs:
           else
             sudo apt-get install -y gcc-multilib g++-multilib
           fi
+
       - name: show tools version
         run: |
           cmake --version
           ${{ steps.compiler.outputs.CC  }} --version
           ${{ steps.compiler.outputs.CXX }} --version
+
       - name: cache extlib
         id: cache-extlib
         uses: actions/cache@v3
         with:
           key: extlib-${{ runner.os }}-${{ hashFiles('./s2e-aobc/s2e-core/ExtLibraries/**') }}-BUILD_64BIT=OFF
-          path: ExtLibraries
+          path: ./s2e-aobc/s2e-core/ExtLibraries
 
       - name: build extlib
         if: steps.cache-extlib.outputs.cache-hit != 'true'
         working-directory: ./s2e-aobc/s2e-core/ExtLibraries
         run: |
           cmake -DBUILD_64BIT=OFF
-          cmake --build .
+          cmake --build . --clean-first
+
       - name: install extlib
         if: steps.cache-extlib.outputs.cache-hit != 'true'
         working-directory: ./s2e-aobc/s2e-core/ExtLibraries
         run: |
           cmake --install .
+
       - name: check extlib
         working-directory: ./s2e-aobc/ExtLibraries
         run: |
@@ -178,6 +183,7 @@ jobs:
           ls nrlmsise00/lib*
           ls nrlmsise00/lib*/libnrlmsise00.a
           ls nrlmsise00/src
+
       - name: build
         working-directory: ./s2e-aobc/s2e-aocs-core
         env:
@@ -185,4 +191,4 @@ jobs:
           CXX: ${{ steps.compiler.outputs.CXX }}
         run: |
           cmake . -DBUILD_64BIT=OFF -DFLIGHT_SW_DIR=../../../ -DC2A_NAME=c2a-aobc -DUSE_C2A=ON
-          cmake --build .
+          cmake --build . --clean-first


### PR DESCRIPTION
## 概要
Fix cache setting for build CI

## Issue
NA

## 詳細
CIでcacheが動いていなかったので、修正

## 検証結果
### ビルドチェック (どちらもチェック)
- [ ] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った -> CIなので関係なし

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
cacheが作られたので、成功している.  
https://github.com/ut-issl/c2a-aobc/actions/caches

## 影響範囲
NA

## 補足
NA

## 注意
NA