### PR TITLE
Update coding rule URL on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ git submodule update
 
 
 # コーディング規則
-- 基本的にCDHが制定している[コーディング規則](https://gitlab.com/ut_issl/c2a/documents_oss/-/blob/master/General/CodingRule.md)に従う
+- 基本的にCDHが制定している[コーディング規則](https://github.com/ut-issl/c2a-core/blob/042cdfa15b0056880398e857cdd5d5a430562fd1/Docs/General/coding_rule.md)に従う
 - その他、AOCSとして特有な下記のことにも気をつける
   - 変数、関数命名時に単位がわかるように配慮する
     - 搭載S/W内では、系内で意思統一した単位系を用いる


### PR DESCRIPTION
## 概要
README.mdにおけるコーディング規約のリンクをGitLabからGitHubのものに修正した

## Issue
NA

## 詳細
URLはsubmoduleのc2a-coreのハッシュに合わせている

## 検証結果
READMEのみの修正のため不要

## 影響範囲
特になし

## 補足
NA

## 注意
- 6U AOCS team Projects への紐付けを行うこと
- Assignees を自分に設定すること
- Reviewers を設定すること
- `priority` ラベルや`major/minor/patch update`ラベルを付けること
