### PR TITLE
CIキャッシュがうまく動いていないようなので修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
         if: steps.cache-extlib.outputs.cache-hit != 'true'
         working-directory: ./s2e-aobc/s2e-core/ExtLibraries
         run: |
-          cmake -DBUILD_64BIT=OFF -DEXT_LIB_DIR="$(pwd)" -DEXT_LIB_DIR="${extlib_dir}"
+          cmake -DBUILD_64BIT=OFF -DEXT_LIB_DIR="$(pwd)"
           cmake --build . --clean-first
 
       - name: install extlib


### PR DESCRIPTION
## 概要
CIキャッシュがうまく動いていないようなので修正

## Issue
NA

## 詳細
s2e-coreやc2a-coreのCIとディレクトリ構成などをできる限り近づけた

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った -> CI変更なので必要ない

### 動作確認チェック (いずれかをチェック) -> CI変更なので必要ない
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
CIで確認  
下を見る限り、キャッシュの利用も含めてうまく動いていそう。

https://github.com/ut-issl/c2a-aobc/actions/runs/5411128537/jobs/9833715114?pr=103


## 影響範囲
NA

## 補足
NA

## 注意
NA