### PR TITLE
Sagittaドライバの修正

### DIFF
--- a/src/src_user/Applications/DriverInstances/di_sagitta.c
+++ b/src/src_user/Applications/DriverInstances/di_sagitta.c
@@ -140,8 +140,6 @@ CCP_CmdRet Cmd_DI_SAGITTA_SET_UNIX_TIME_US(const CommonCmdPacket* packet)
 
 CCP_CmdRet Cmd_DI_SAGITTA_SET_PARAMETER(const CommonCmdPacket* packet)
 {
-  if (!DI_SAGITTA_is_booted_[SAGITTA_IDX_IN_UNIT])  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
-
   uint8_t param_id = CCP_get_param_from_packet(packet, 0, uint8_t);
 
   DS_CMD_ERR_CODE ret;
@@ -244,8 +242,6 @@ CCP_CmdRet Cmd_DI_SAGITTA_CHANGE_PARAMETER(const CommonCmdPacket* packet)
 
 CCP_CmdRet Cmd_DI_SAGITTA_READ_PARAMETER(const CommonCmdPacket* packet)
 {
-  if (!DI_SAGITTA_is_booted_[SAGITTA_IDX_IN_UNIT])  return CCP_make_cmd_ret_without_err_code(CCP_EXEC_ILLEGAL_CONTEXT);
-
   DS_CMD_ERR_CODE ret;
   uint8_t param_id = CCP_get_param_from_packet(packet, 0, uint8_t);
 

--- a/src/src_user/Drivers/Aocs/sagitta.c
+++ b/src/src_user/Drivers/Aocs/sagitta.c
@@ -738,7 +738,7 @@ DS_CMD_ERR_CODE SAGITTA_change_camera(SAGITTA_Driver* sagitta_driver, uint8_t pa
     sagitta_driver->info.set_parameter.camera.interval_s = value;
     break;
   case 4:
-    sagitta_driver->info.set_parameter.camera.offset_pix = (uint16_t)value;
+    sagitta_driver->info.set_parameter.camera.offset_pix = (int16_t)value;
     break;
   case 5:
     sagitta_driver->info.set_parameter.camera.pga_gain = (uint8_t)value;


### PR DESCRIPTION
## 概要
Sagittaドライバの修正

## Issue
#21 

## 詳細
- bootしたかどうかのフラグ管理方法の見直し
bootしていない状態でSagittaとテレコマ通信するモードも存在する。パラメータ変更等のアサーションにbootフラグは使わない。
- キャスト不具合修正


## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

bootフラグが立っていなくても、パラメータset/readコマンドが弾かれないことを確認。

camera.offset_pixに負の値を入れられることを確認。
![image](https://github.com/ut-issl/c2a-aobc/assets/82629762/6bb1595f-7921-437f-9fe3-c8ae908af11c)


### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 図や表で記述する

## 影響範囲
XX系の動作がガラッと変わる，とか．

## 補足
何かあれば

## 注意
- 6U AOCS team Projects への紐付けを行うこと
- Assignees を自分に設定すること
- Reviewers を設定すること
- `priority` ラベルや`major/minor/patch update`ラベルを付けること
