### PR TITLE
Add minimum torque limit for unloading

### DIFF
--- a/Examples/src_aobc_example/Settings/SatelliteParameters/attitude_control_parameters.c
+++ b/Examples/src_aobc_example/Settings/SatelliteParameters/attitude_control_parameters.c
@@ -81,6 +81,7 @@ const float ATTITUDE_CONTROL_PARAMETERS_unloading_angular_velocity_lower_thresho
 const float ATTITUDE_CONTROL_PARAMETERS_unloading_angular_velocity_target_rad_s = PARAMETER_SETTING_MACRO_RPM_TO_RADIAN_SEC(0.0f);
 const float ATTITUDE_CONTROL_PARAMETERS_unloading_control_gain = -1.0e-7f;
 const APP_UNLOADING_EXEC ATTITUDE_CONTROL_PARAMETERS_unloading_exec_is_enable = APP_UNLOADING_EXEC_DISABLE;
+const float ATTITUDE_CONTROL_PARAMETERS_unloading_minimum_torque_Nm = 1.0e-7f;
 
 // Control Torques
 const AOCS_MANAGER_CONSTANT_TORQUE_PERMISSION ATTITUDE_CONTROL_PARAMETERS_constant_torque_permission = AOCS_MANAGER_CONSTANT_TORQUE_DISABLE;

--- a/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/unloading.c
+++ b/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/unloading.c
@@ -152,27 +152,23 @@ void APP_UNLOADING_calc_output_torque(void)
     if (unloading_.unloading_state[idx] != APP_UNLOADING_STATE_OFF)
     {
       float exceed_angular_velocity_rad_s = aocs_manager->rw_angular_velocity_rad_s[idx] - unloading_.angular_velocity_target_rad_s;
-      float exceed_angular_velocity_vec_rad_s[PHYSICAL_CONST_THREE_DIM]; //!< 目標回転角速度に対して、余分に持っている回転角速度ベクトル
-      VECTOR3_scalar_product(exceed_angular_velocity_vec_rad_s, exceed_angular_velocity_rad_s, aocs_manager->rw_rotation_direction_matrix[idx]);
+      float scalar_output_torque_Nm = exceed_angular_velocity_rad_s * unloading_.control_gain;
+      // Check sign
+      float sign = 1.0f;
+      if (scalar_output_torque_Nm < 0.0f)
+      {
+        sign = -1.0f;
+      }
+      // Check minimum value
+      float abs_output_torque_Nm = fabsf(scalar_output_torque_Nm);
+      if (abs_output_torque_Nm < ATTITUDE_CONTROL_PARAMETERS_unloading_minimum_torque_Nm)
+      {
+        scalar_output_torque_Nm = sign * ATTITUDE_CONTROL_PARAMETERS_unloading_minimum_torque_Nm;
+      }
+
       float output_torque_tmp_Nm[PHYSICAL_CONST_THREE_DIM]; //!< その軸のRWをアンローディングするのに必要な出力トルク
-      VECTOR3_scalar_product(output_torque_tmp_Nm, unloading_.control_gain, exceed_angular_velocity_vec_rad_s);
+      VECTOR3_scalar_product(output_torque_tmp_Nm, scalar_output_torque_Nm, aocs_manager->rw_rotation_direction_matrix[idx]);
       VECTOR3_add(unloading_.output_torque_body_Nm, unloading_.output_torque_body_Nm, output_torque_tmp_Nm);
-    }
-  }
-  // Set minimum torque
-  for (uint8_t axis = 0; axis < PHYSICAL_CONST_THREE_DIM; axis++)
-  {
-    // Check sign
-    float sign = 1.0f;
-    if (unloading_.output_torque_body_Nm[axis] < 0.0f)
-    {
-      sign = -1.0f;
-    }
-    // Check minimum value
-    float abs_output_torque_Nm = fabsf(unloading_.output_torque_body_Nm[axis]);
-    if (abs_output_torque_Nm < ATTITUDE_CONTROL_PARAMETERS_unloading_minimum_torque_Nm)
-    {
-      unloading_.output_torque_body_Nm[axis] = sign * ATTITUDE_CONTROL_PARAMETERS_unloading_minimum_torque_Nm;
     }
   }
 }

--- a/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/unloading.c
+++ b/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/unloading.c
@@ -74,7 +74,7 @@ void APP_UNLOADING_exec_(void)
   APP_UNLOADING_update_unloading_state_();
   APP_UNLOADING_calc_output_torque();
 
-  // アンローディング処理がenableになっているときのみ，出力目標トルクをAOCS Manegerにセットする
+  // アンローディング処理がenableになっているときのみ，出力目標トルクをAOCS Managerにセットする
   // disableのときは，出力目標トルクのセットはしないが，トルク計算自体はcalc_torque_outputで行われている．
   if (unloading_.exec_is_enable == APP_UNLOADING_EXEC_ENABLE)
   {

--- a/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/unloading.c
+++ b/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/unloading.c
@@ -159,6 +159,22 @@ void APP_UNLOADING_calc_output_torque(void)
       VECTOR3_add(unloading_.output_torque_body_Nm, unloading_.output_torque_body_Nm, output_torque_tmp_Nm);
     }
   }
+  // Set minimum torque
+  for (uint8_t axis = 0; axis < PHYSICAL_CONST_THREE_DIM; axis++)
+  {
+    // Check sign
+    float sign = 1.0f;
+    if (unloading_.output_torque_body_Nm[axis] < 0.0f)
+    {
+      sign = -1.0f;
+    }
+    // Check minimum value
+    float abs_output_torque_Nm = fabsf(unloading_.output_torque_body_Nm[axis]);
+    if (abs_output_torque_Nm < ATTITUDE_CONTROL_PARAMETERS_unloading_minimum_torque_Nm)
+    {
+      unloading_.output_torque_body_Nm[axis] = sign * ATTITUDE_CONTROL_PARAMETERS_unloading_minimum_torque_Nm;
+    }
+  }
 }
 
 CCP_CmdRet Cmd_APP_UNLOADING_SET_ENABLE(const CommonCmdPacket* packet)

--- a/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/unloading.h
+++ b/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/unloading.h
@@ -65,7 +65,7 @@ extern const Unloading* const unloading;
 AppInfo APP_UNLOADING_create_app(void);
 
 CCP_CmdRet Cmd_APP_UNLOADING_SET_ENABLE(const CommonCmdPacket* packet);
-CCP_CmdRet Cmd_APP_UNLOADING_SET_ANGULAR_VEROCITY_THRESHOLD(const CommonCmdPacket* packet);
+CCP_CmdRet Cmd_APP_UNLOADING_SET_ANGULAR_VEROCITY_THRESHOLD(const CommonCmdPacket* packet); // TODO_L: Fix typo VEROCITY -> VELOCITY. Cmd DBも変わるので注意
 CCP_CmdRet Cmd_APP_UNLOADING_SET_CONTROL_GAIN(const CommonCmdPacket* packet);
 
 

--- a/src/src_user/Settings/SatelliteParameters/Sample/attitude_control_parameters.c
+++ b/src/src_user/Settings/SatelliteParameters/Sample/attitude_control_parameters.c
@@ -81,6 +81,7 @@ const float ATTITUDE_CONTROL_PARAMETERS_unloading_angular_velocity_lower_thresho
 const float ATTITUDE_CONTROL_PARAMETERS_unloading_angular_velocity_target_rad_s = PARAMETER_SETTING_MACRO_RPM_TO_RADIAN_SEC(0.0f);
 const float ATTITUDE_CONTROL_PARAMETERS_unloading_control_gain = -1.0e-7f;
 const APP_UNLOADING_EXEC ATTITUDE_CONTROL_PARAMETERS_unloading_exec_is_enable = APP_UNLOADING_EXEC_DISABLE;
+const float ATTITUDE_CONTROL_PARAMETERS_unloading_minimum_torque_Nm = 1.0e-7f;
 
 // Control Torques
 const AOCS_MANAGER_CONSTANT_TORQUE_PERMISSION ATTITUDE_CONTROL_PARAMETERS_constant_torque_permission = AOCS_MANAGER_CONSTANT_TORQUE_DISABLE;

--- a/src/src_user/Settings/SatelliteParameters/attitude_control_parameters.h
+++ b/src/src_user/Settings/SatelliteParameters/attitude_control_parameters.h
@@ -88,6 +88,7 @@ extern const float ATTITUDE_CONTROL_PARAMETERS_unloading_angular_velocity_lower_
 extern const float ATTITUDE_CONTROL_PARAMETERS_unloading_angular_velocity_target_rad_s;           //!< Unloading target [rad/s]
 extern const float ATTITUDE_CONTROL_PARAMETERS_unloading_control_gain;                            //!< Unloading gain
 extern const APP_UNLOADING_EXEC ATTITUDE_CONTROL_PARAMETERS_unloading_exec_is_enable;             //!< Unloading execution enable flag
+extern const float ATTITUDE_CONTROL_PARAMETERS_unloading_minimum_torque_Nm;                       //!< Unloading minimum torque [Nm]
 
 // Control Torques
 extern const AOCS_MANAGER_CONSTANT_TORQUE_PERMISSION ATTITUDE_CONTROL_PARAMETERS_constant_torque_permission;  //!< Constant torque correction permission


### PR DESCRIPTION
## Issue
- #46 

## 詳細
- 最小出力トルクを設定できるようにアンローディングアルゴリズムを修正した
- 最小値はプロジェクト毎に変わる可能性があるので、SatelliteParameterを追加した。

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 追加した最小トルク設定アルゴリズムが正しく動くことを確認した

<img width="1591" alt="image" src="https://github.com/ut-issl/c2a-aobc/assets/19573779/b5446747-07c4-4a34-8f9b-eabffbe3595a">

- 精三軸制御モードでアンローディングが問題なくできることを確認した

<img width="743" alt="image" src="https://github.com/ut-issl/c2a-aobc/assets/19573779/31a97e55-667e-4e7c-8fb8-f6daea1d10a8">


## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
