### PR TITLE
tlm cmd generator を submodule として持たせる

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/src_core"]
 	path = src/src_core
 	url = https://github.com/ut-issl/c2a-core
+[submodule "tools/tlm_cmd_generator"]
+	path = tools/tlm_cmd_generator
+	url = https://github.com/ut-issl/c2a-tlm-cmd-code-generator.git

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
   - For SILS test
     - [S2E-AOBC](https://github.com/ut-issl/s2e-aobc) v3.0.0
   - Telemetry/Command interface
-    - [tlm-cmd-generator](https://github.com/ut-issl/c2a-tlm-cmd-code-generator)
-      - Version: [ISSL Branch](https://github.com/ut-issl/c2a-tlm-cmd-code-generator/tree/feature/issl)
     - [WINGS](https://gitlab.com/ut_issl/wings/wings)
 - How to use
   - `The main developers` of the AOCS module directly use this repository to add new features and improve the module.
@@ -57,8 +55,8 @@
 - The term `body-fixed frame` in the codes and tlm/cmd database means `the body-fixed frame of the AOCS module`. It does not necessarily coincide with the body-fixed frame of your satellite.
 
 ## For main developers
-## How to clone the repository
-  - This repository includes [c2a-core](https://github.com/ut-issl/c2a-core) with the `git submodule`. Please use the following commands to construct the directory.
+### How to clone the repository
+  - This repository includes [c2a-core](https://github.com/ut-issl/c2a-core) and [tlm-cmd-generator](https://github.com/ut-issl/c2a-tlm-cmd-code-generator) as the `git submodule`. Please use the following commands to construct the directory.
     ```
     $ git clone git@github.com:ut-issl/c2a-aobc.git
     $ cd c2a-aobc/
@@ -108,22 +106,10 @@
 ### How to edit TLM/CMD (Telemetry/Command)
 1. Edit TLM/CMD DB in `c2a-aobc/database/`
    - Please find detailed information on [How to use TLM/CMD DB](https://github.com/ut-issl/tlm-cmd-db).
-2. Execute `tlm-cmd-generator` and generate source codes.
+2. Execute `tools/tlm_cmd_generator` and generate source codes.
    - [How to use tlm-cmd-generator](https://github.com/ut-issl/c2a-tlm-cmd-code-generator)
-   - Checkout to the latest [feature/issl](https://github.com/ut-issl/c2a-tlm-cmd-code-generator/tree/feature/issl) branch.
-   - Edit the `settings.json` as follows.
-     ```
-     {
-       "path_to_src" : "Relative path to c2a-aobc/src/",
-       "path_to_db" : "Relative path to c2a-aobc/database/",
-       "db_prefix" : "ISSL6U_AOBC",
-       "tlm_id_range" : ["0x00", "0x100"],
-       "is_cmd_prefixed_in_db" : 1,
-       "input_file_encoding" : "utf-8",
-       "output_file_encoding" : "utf-8",
-       "is_main_obc" : 0
-     }
-     ```
+   - Just use the version specified in the submodule.
+   - It is set to read `tools/tlm_cmd_gen_config.json` as the config file.
 
 
 ### Development style

--- a/tools/tlm_cmd_gen_config.json
+++ b/tools/tlm_cmd_gen_config.json
@@ -1,0 +1,10 @@
+{
+    "path_to_src" : "../../src/",
+    "path_to_db" : "../../database/",
+    "db_prefix" : "ISSL6U_AOBC",
+    "tlm_id_range" : ["0x00", "0x100"],
+    "is_cmd_prefixed_in_db" : 1,
+    "input_file_encoding" : "utf-8",
+    "output_file_encoding" : "utf-8",
+    "is_main_obc" : 0
+}


### PR DESCRIPTION
## Issue
N/A

## 詳細
以下の理由から、tlm cmd generator を submodule で持ち、settings.json も C2A 側で持つことにした

- mainに微修正を入れたfeature/isslブランチを使っているが、その周知が行きわたらずミスが多発している
- setitngs.json は C2A 側で持った方が管理が楽だしミスも減らせる
- CDH以外がtlm-cmd-generatorを明示的にcloneするのがコスト高いので、初めからリポジトリ内に入ってると嬉しい

## 検証結果
ソースコード自体に変更はない。
tlm cmd generator の動作は手元で確認した。

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 図や表で記述する

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
