### PR TITLE
Resize the driver receive buffer

### DIFF
--- a/src/src_user/Applications/DriverInstances/di_fm25v10.c
+++ b/src/src_user/Applications/DriverInstances/di_fm25v10.c
@@ -13,6 +13,8 @@
 #include <src_user/Settings/DriverSuper/driver_buffer_define.h>
 #include <math.h>
 
+#define DS_STREAM_REC_BUFFER_SIZE_FM25V10 (DS_IF_RX_BUFFER_SIZE_FM25V10)  //!< DS_StreamRecBuffer のバッファサイズ
+
 static void DI_FM25V10_init_(void);
 static void DI_FM25V10_update_(void);
 
@@ -23,7 +25,7 @@ const  FM25V10_Driver* const fm25v10_driver[FM25V10_IDX_MAX] = {&fm25v10_driver_
                                                                 &fm25v10_driver_[FM25V10_IDX_4]};
 // バッファ
 static DS_StreamRecBuffer DI_FM25V10_rx_buffer_[FM25V10_IDX_MAX];
-static uint8_t DI_FM25V10_rx_buffer_allocation_[FM25V10_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static uint8_t DI_FM25V10_rx_buffer_allocation_[FM25V10_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_FM25V10];
 
 
 /**

--- a/src/src_user/Applications/DriverInstances/di_ina260.c
+++ b/src/src_user/Applications/DriverInstances/di_ina260.c
@@ -33,7 +33,7 @@ const  INA260_Driver* const ina260_driver[INA260_IDX_MAX] = {&ina260_driver_[INA
                                                              &ina260_driver_[INA260_IDX_RW0003_Z]};
 // バッファ
 static DS_StreamRecBuffer DI_INA260_rx_buffer_[INA260_IDX_MAX];
-static uint8_t DI_INA260_rx_buffer_allocation_[INA260_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static uint8_t DI_INA260_rx_buffer_allocation_[INA260_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_I2C];
 
 static uint8_t    DI_INA260_is_initialized_[INA260_IDX_MAX]; //!< 0 = not initialized, 1 = initialized
 static INA260_IDX DI_INA260_idx_counter_ = (INA260_IDX)(0);  //!< DI_INA260_update_が呼ばれたときに観測する電流センサを指定するカウンタ．

--- a/src/src_user/Applications/DriverInstances/di_ina260.c
+++ b/src/src_user/Applications/DriverInstances/di_ina260.c
@@ -33,7 +33,7 @@ const  INA260_Driver* const ina260_driver[INA260_IDX_MAX] = {&ina260_driver_[INA
                                                              &ina260_driver_[INA260_IDX_RW0003_Z]};
 // バッファ
 static DS_StreamRecBuffer DI_INA260_rx_buffer_[INA260_IDX_MAX];
-static uint8_t DI_INA260_rx_buffer_allocation_[INA260_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_I2C];
+static uint8_t DI_INA260_rx_buffer_allocation_[INA260_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL];
 
 static uint8_t    DI_INA260_is_initialized_[INA260_IDX_MAX]; //!< 0 = not initialized, 1 = initialized
 static INA260_IDX DI_INA260_idx_counter_ = (INA260_IDX)(0);  //!< DI_INA260_update_が呼ばれたときに観測する電流センサを指定するカウンタ．

--- a/src/src_user/Applications/DriverInstances/di_mobc.c
+++ b/src/src_user/Applications/DriverInstances/di_mobc.c
@@ -10,6 +10,8 @@
 #include <src_user/Settings/port_config.h>
 #include <src_user/Settings/DriverSuper/driver_buffer_define.h>
 
+#define DS_STREAM_REC_BUFFER_SIZE_MOBC (DS_IF_RX_BUFFER_SIZE_MOBC * 2)  //!< DS_StreamRecBuffer のバッファサイズ（非同期通信なので2倍している）
+
 static void DI_MOBC_init_(void);
 static void DI_MOBC_update_(void);
 static void DI_MOBC_ms_tlm_packet_handler_init_(void);
@@ -20,7 +22,7 @@ const MOBC_Driver* const mobc_driver = &mobc_driver_;
 
 // バッファ
 static DS_StreamRecBuffer DI_MOBC_rx_buffer_;
-static uint8_t DI_MOBC_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static uint8_t DI_MOBC_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_MOBC];
 
 /**
  * 一度に送出する最大テレメ数

--- a/src/src_user/Applications/DriverInstances/di_mpu9250.c
+++ b/src/src_user/Applications/DriverInstances/di_mpu9250.c
@@ -30,8 +30,8 @@ const  DiMpu9250* const di_mpu9250[MPU9250_IDX_MAX] = {&di_mpu9250_[MPU9250_IDX_
 // バッファ
 static DS_StreamRecBuffer DI_MPU9250_rx_buffer_;
 static DS_StreamRecBuffer DI_AK8963_rx_buffer_;
-static uint8_t DI_MPU9250_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_I2C];
-static uint8_t DI_AK8963_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_I2C];
+static uint8_t DI_MPU9250_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL];
+static uint8_t DI_AK8963_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL];
 
 static uint8_t DI_MPU9250_is_initialized_[MPU9250_IDX_MAX] = { 0 };  //!< 0 = not initialized, 1 = initialized
 

--- a/src/src_user/Applications/DriverInstances/di_mpu9250.c
+++ b/src/src_user/Applications/DriverInstances/di_mpu9250.c
@@ -30,8 +30,8 @@ const  DiMpu9250* const di_mpu9250[MPU9250_IDX_MAX] = {&di_mpu9250_[MPU9250_IDX_
 // バッファ
 static DS_StreamRecBuffer DI_MPU9250_rx_buffer_;
 static DS_StreamRecBuffer DI_AK8963_rx_buffer_;
-static uint8_t DI_MPU9250_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
-static uint8_t DI_AK8963_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static uint8_t DI_MPU9250_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_I2C];
+static uint8_t DI_AK8963_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_I2C];
 
 static uint8_t DI_MPU9250_is_initialized_[MPU9250_IDX_MAX] = { 0 };  //!< 0 = not initialized, 1 = initialized
 

--- a/src/src_user/Applications/DriverInstances/di_nanossoc_d60.c
+++ b/src/src_user/Applications/DriverInstances/di_nanossoc_d60.c
@@ -36,7 +36,7 @@ const  NANOSSOC_D60_Driver* const nanossoc_d60_driver[NANOSSOC_D60_IDX_MAX]
                                                         &nanossoc_d60_driver_[NANOSSOC_D60_IDX_ON_MZ]};
 // バッファ
 static DS_StreamRecBuffer DI_NANOSSOC_D60_rx_buffer_[NANOSSOC_D60_IDX_MAX];
-static uint8_t DI_NANOSSOC_D60_rx_buffer_allocation_[NANOSSOC_D60_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_I2C];
+static uint8_t DI_NANOSSOC_D60_rx_buffer_allocation_[NANOSSOC_D60_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL];
 
 static NANOSSOC_D60_IDX NANOSSOC_D60_idx_counter_ = NANOSSOC_D60_IDX_ON_PY; // DI_NANOSSOC_D60_update_が呼ばれたときにアップデートするサンセンサを指定するカウンタ．
 

--- a/src/src_user/Applications/DriverInstances/di_nanossoc_d60.c
+++ b/src/src_user/Applications/DriverInstances/di_nanossoc_d60.c
@@ -36,7 +36,7 @@ const  NANOSSOC_D60_Driver* const nanossoc_d60_driver[NANOSSOC_D60_IDX_MAX]
                                                         &nanossoc_d60_driver_[NANOSSOC_D60_IDX_ON_MZ]};
 // バッファ
 static DS_StreamRecBuffer DI_NANOSSOC_D60_rx_buffer_[NANOSSOC_D60_IDX_MAX];
-static uint8_t DI_NANOSSOC_D60_rx_buffer_allocation_[NANOSSOC_D60_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static uint8_t DI_NANOSSOC_D60_rx_buffer_allocation_[NANOSSOC_D60_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_I2C];
 
 static NANOSSOC_D60_IDX NANOSSOC_D60_idx_counter_ = NANOSSOC_D60_IDX_ON_PY; // DI_NANOSSOC_D60_update_が呼ばれたときにアップデートするサンセンサを指定するカウンタ．
 

--- a/src/src_user/Applications/DriverInstances/di_oem7600.c
+++ b/src/src_user/Applications/DriverInstances/di_oem7600.c
@@ -13,6 +13,8 @@
 #include <src_user/Applications/UserDefined/Power/power_switch_control.h>
 #include <src_user/Applications/UserDefined/AOCS/aocs_manager.h>
 
+#define DS_STREAM_REC_BUFFER_SIZE_OEM7600 (DS_IF_RX_BUFFER_SIZE_OEM7600 * 2)  //!< DS_StreamRecBuffer のバッファサイズ（非同期通信なので2倍している）
+
 static void DI_OEM7600_init_(void);
 static void DI_OEM7600_update_(void);
 
@@ -22,7 +24,7 @@ const  OEM7600_Driver* const oem7600_driver[OEM7600_IDX_MAX] = { &oem7600_driver
 // バッファ
 // 面倒くさいので要素数一つと仮定してバッファを確保する
 static DS_StreamRecBuffer DI_OEM7600_rx_buffer_;
-static uint8_t DI_OEM7600_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static uint8_t DI_OEM7600_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_OEM7600];
 
 
 AppInfo DI_OEM7600_update(void)

--- a/src/src_user/Applications/DriverInstances/di_rm3100.c
+++ b/src/src_user/Applications/DriverInstances/di_rm3100.c
@@ -26,7 +26,7 @@ const  RM3100_Driver* const rm3100_driver[RM3100_IDX_MAX] = {&rm3100_driver_[RM3
                                                              &rm3100_driver_[RM3100_IDX_EXTERNAL]};
 // バッファ
 static DS_StreamRecBuffer DI_RM3100_rx_buffer_[RM3100_IDX_MAX];
-static uint8_t DI_RM3100_rx_buffer_allocation_[RM3100_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_I2C];
+static uint8_t DI_RM3100_rx_buffer_allocation_[RM3100_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL];
 
 static uint8_t DI_RM3100_is_initialized_[RM3100_IDX_MAX] = { 0, 0 };  //!< 0 = not initialized, 1 = initialized
 

--- a/src/src_user/Applications/DriverInstances/di_rm3100.c
+++ b/src/src_user/Applications/DriverInstances/di_rm3100.c
@@ -26,7 +26,7 @@ const  RM3100_Driver* const rm3100_driver[RM3100_IDX_MAX] = {&rm3100_driver_[RM3
                                                              &rm3100_driver_[RM3100_IDX_EXTERNAL]};
 // バッファ
 static DS_StreamRecBuffer DI_RM3100_rx_buffer_[RM3100_IDX_MAX];
-static uint8_t DI_RM3100_rx_buffer_allocation_[RM3100_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static uint8_t DI_RM3100_rx_buffer_allocation_[RM3100_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_I2C];
 
 static uint8_t DI_RM3100_is_initialized_[RM3100_IDX_MAX] = { 0, 0 };  //!< 0 = not initialized, 1 = initialized
 

--- a/src/src_user/Applications/DriverInstances/di_rw0003.c
+++ b/src/src_user/Applications/DriverInstances/di_rw0003.c
@@ -26,7 +26,7 @@ const  RW0003_Driver* const rw0003_driver[RW0003_IDX_MAX] = {&rw0003_driver_[RW0
                                                              &rw0003_driver_[RW0003_IDX_ON_Z]};
 // バッファ
 static DS_StreamRecBuffer DI_RW0003_rx_buffer_[RW0003_IDX_MAX];
-static uint8_t DI_RW0003_rx_buffer_allocation_[RW0003_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static uint8_t DI_RW0003_rx_buffer_allocation_[RW0003_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_I2C];
 
 static float DI_RW0003_rw_speed_rad_s_[RW0003_IDX_MAX] = {0.0f, 0.0f, 0.0f};
 static uint8_t DI_RW0003_is_initialized_[RW0003_IDX_MAX];  //!< 0 = not initialized, 1 = initialized

--- a/src/src_user/Applications/DriverInstances/di_rw0003.c
+++ b/src/src_user/Applications/DriverInstances/di_rw0003.c
@@ -26,7 +26,7 @@ const  RW0003_Driver* const rw0003_driver[RW0003_IDX_MAX] = {&rw0003_driver_[RW0
                                                              &rw0003_driver_[RW0003_IDX_ON_Z]};
 // バッファ
 static DS_StreamRecBuffer DI_RW0003_rx_buffer_[RW0003_IDX_MAX];
-static uint8_t DI_RW0003_rx_buffer_allocation_[RW0003_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_I2C];
+static uint8_t DI_RW0003_rx_buffer_allocation_[RW0003_IDX_MAX][DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL];
 
 static float DI_RW0003_rw_speed_rad_s_[RW0003_IDX_MAX] = {0.0f, 0.0f, 0.0f};
 static uint8_t DI_RW0003_is_initialized_[RW0003_IDX_MAX];  //!< 0 = not initialized, 1 = initialized

--- a/src/src_user/Applications/DriverInstances/di_stim210.c
+++ b/src/src_user/Applications/DriverInstances/di_stim210.c
@@ -17,6 +17,8 @@
 // Satellite Parameters
 #include <src_user/Settings/SatelliteParameters/stim210_parameters.h>
 
+#define DS_STREAM_REC_BUFFER_SIZE_STIM210 (DS_IF_RX_BUFFER_SIZE_STIM210 * 2)  //!< DS_StreamRecBuffer のバッファサイズ（非同期通信なので2倍している）
+
 static void DI_STIM210_init_(void);
 static void DI_STIM210_update_(void);
 static void DI_STIM210_temperature_caliblation_(void);
@@ -30,7 +32,7 @@ const  DiStim210* const di_stim210 [STIM210_IDX_MAX] = {&di_stim210_[STIM210_IDX
 // バッファ
 // 面倒くさいので要素数一つと仮定してバッファを確保する
 static DS_StreamRecBuffer DI_STIM210_rx_buffer_;
-static uint8_t DI_STIM210_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_DEFAULT];
+static uint8_t DI_STIM210_rx_buffer_allocation_[DS_STREAM_REC_BUFFER_SIZE_STIM210];
 
 AppInfo DI_STIM210_update(void)
 {

--- a/src/src_user/Drivers/Aocs/mpu9250.c
+++ b/src/src_user/Drivers/Aocs/mpu9250.c
@@ -152,7 +152,7 @@ static DS_ERR_CODE MPU9250_gyro_load_driver_super_init_settings_(DriverSuper* su
 
   stream_config = &(super->stream_config[MPU9250_STREAM_TLM_CMD]);
 
-  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL);
 
   DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, MPU9250_GYRO_RX_FRAME_SIZE);
@@ -169,7 +169,7 @@ static DS_ERR_CODE MPU9250_mag_load_driver_super_init_settings_(DriverSuper* sup
 
   stream_config = &(super->stream_config[MPU9250_STREAM_TLM_CMD]);
 
-  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL);
 
   DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, MPU9250_MAG_RX_FRAME_SIZE);

--- a/src/src_user/Drivers/Aocs/mpu9250.c
+++ b/src/src_user/Drivers/Aocs/mpu9250.c
@@ -9,6 +9,7 @@
 #include <src_user/Library/physical_constants.h>
 #include <src_user/Library/vector3.h>
 #include <src_user/Library/matrix33.h>
+#include <src_user/Settings/DriverSuper/driver_buffer_define.h>
 
 #define MPU9250_STREAM_TLM_CMD         (0)  //!< テレコマで使うストリーム
 #define MPU9250_TX_FOR_REC_FRAME_SIZE  (1)  //!< 観測時の1回の送信データ長（バイト）
@@ -151,6 +152,8 @@ static DS_ERR_CODE MPU9250_gyro_load_driver_super_init_settings_(DriverSuper* su
 
   stream_config = &(super->stream_config[MPU9250_STREAM_TLM_CMD]);
 
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+
   DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, MPU9250_GYRO_RX_FRAME_SIZE);
   DSSC_set_data_analyzer(stream_config, MPU9250_gyro_analyze_rec_data_);
@@ -165,6 +168,8 @@ static DS_ERR_CODE MPU9250_mag_load_driver_super_init_settings_(DriverSuper* sup
   super->interface = I2C;
 
   stream_config = &(super->stream_config[MPU9250_STREAM_TLM_CMD]);
+
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
 
   DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, MPU9250_MAG_RX_FRAME_SIZE);

--- a/src/src_user/Drivers/Aocs/nanossoc_d60.c
+++ b/src/src_user/Drivers/Aocs/nanossoc_d60.c
@@ -5,9 +5,10 @@
 */
 
 #include "nanossoc_d60.h"
-#include <src_user/Library/vector3.h>
-#include <string.h> // for memcpy
 #include <math.h>
+#include <string.h> // for memcpy
+#include <src_user/Library/vector3.h>
+#include <src_user/Settings/DriverSuper/driver_buffer_define.h>
 
 #define NANOSSOC_D60_STREAM_TLM_CMD (0)  //!< テレコマで使うストリーム
 #define NANOSSOC_D60_RX_FRAME_SIZE  (15) //!< 1回の受信で取得するデータ長（バイト）
@@ -61,6 +62,9 @@ static DS_ERR_CODE NANOSSOC_D60_load_driver_super_init_settings_(DriverSuper* su
 
   // streamは0のみ
   stream_config = &(super->stream_config[NANOSSOC_D60_STREAM_TLM_CMD]);
+
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+
   DSSC_enable(stream_config);
 
   // 送信

--- a/src/src_user/Drivers/Aocs/nanossoc_d60.c
+++ b/src/src_user/Drivers/Aocs/nanossoc_d60.c
@@ -63,7 +63,7 @@ static DS_ERR_CODE NANOSSOC_D60_load_driver_super_init_settings_(DriverSuper* su
   // streamは0のみ
   stream_config = &(super->stream_config[NANOSSOC_D60_STREAM_TLM_CMD]);
 
-  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL);
 
   DSSC_enable(stream_config);
 

--- a/src/src_user/Drivers/Aocs/oem7600.c
+++ b/src/src_user/Drivers/Aocs/oem7600.c
@@ -126,6 +126,9 @@ static DS_ERR_CODE OEM7600_load_driver_super_init_settings_(DriverSuper* p_super
 
   // streamは0のみ
   p_stream_config = &(p_super->stream_config[OEM7600_STREAM_TLM_CMD]);
+
+  DSC_set_rx_buffer_size_in_if_rx(p_super, DS_IF_RX_BUFFER_SIZE_OEM7600);
+
   DSSC_enable(p_stream_config);
 
   // 送信はする

--- a/src/src_user/Drivers/Aocs/oem7600.h
+++ b/src/src_user/Drivers/Aocs/oem7600.h
@@ -13,6 +13,8 @@
 
 #define OEM7600_MAX_SAT_NUM_RANGE_STORE (12) //!< rangeテレメの格納対象とする同時可視最大衛星数
 
+#define DS_IF_RX_BUFFER_SIZE_OEM7600 (144)  //!< IF_RXのバッファサイズ
+
 /**
 * @enum  OEM7600_DATA_UPDATE_STATUS
 * @brief レンジデータが最新値か（可視衛星不足により）過去値が残ったままか．

--- a/src/src_user/Drivers/Aocs/rm3100.c
+++ b/src/src_user/Drivers/Aocs/rm3100.c
@@ -161,7 +161,7 @@ static DS_ERR_CODE RM3100_load_driver_super_init_settings_(DriverSuper* super)
 
   stream_config = &(super->stream_config[RM3100_STREAM_TLM_CMD]);
 
-  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL);
 
   DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, RM3100_RX_FRAME_SIZE);

--- a/src/src_user/Drivers/Aocs/rm3100.c
+++ b/src/src_user/Drivers/Aocs/rm3100.c
@@ -8,6 +8,7 @@
 #include <src_user/Library/matrix33.h>
 #include <src_user/Library/vector3.h>
 #include <src_user/Library/c2a_math.h>
+#include <src_user/Settings/DriverSuper/driver_buffer_define.h>
 
 #define RM3100_STREAM_TLM_CMD  (0)
 #define RM3100_RX_FRAME_SIZE   (9)  //!< RM3100の場合この値で固定
@@ -159,8 +160,10 @@ static DS_ERR_CODE RM3100_load_driver_super_init_settings_(DriverSuper* super)
   super->interface = I2C;
 
   stream_config = &(super->stream_config[RM3100_STREAM_TLM_CMD]);
-  DSSC_enable(stream_config);
 
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+
+  DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, RM3100_RX_FRAME_SIZE);
   DSSC_set_data_analyzer(stream_config, RM3100_analyze_rec_data_);
 

--- a/src/src_user/Drivers/Aocs/rw0003.c
+++ b/src/src_user/Drivers/Aocs/rw0003.c
@@ -269,7 +269,7 @@ static DS_ERR_CODE RW0003_load_driver_super_init_settings_(DriverSuper* super)
 
   stream_config = &(super->stream_config[RW0003_STREAM_TLM_CMD]);
 
-  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL);
 
   DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, RW0003_RX_MAX_FRAME_SIZE);  // 可変だがサイズ情報なし, 都度設定する

--- a/src/src_user/Drivers/Aocs/rw0003.c
+++ b/src/src_user/Drivers/Aocs/rw0003.c
@@ -15,6 +15,7 @@
 #include <src_core/Library/crc.h>
 #include <src_user/Library/vector3.h>
 #include <src_user/Library/c2a_math.h>
+#include <src_user/Settings/DriverSuper/driver_buffer_define.h>
 
 // #define DRIVER_RW0003_DEBUG_SHOW_REC_DATA
 
@@ -267,8 +268,10 @@ static DS_ERR_CODE RW0003_load_driver_super_init_settings_(DriverSuper* super)
   super->interface = I2C;
 
   stream_config = &(super->stream_config[RW0003_STREAM_TLM_CMD]);
-  DSSC_enable(stream_config);
 
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+
+  DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, RW0003_RX_MAX_FRAME_SIZE);  // 可変だがサイズ情報なし, 都度設定する
   DSSC_set_data_analyzer(stream_config, RW0003_analyze_rec_data_);
 

--- a/src/src_user/Drivers/Aocs/stim210.c
+++ b/src/src_user/Drivers/Aocs/stim210.c
@@ -469,6 +469,9 @@ static DS_ERR_CODE STIM210_load_driver_super_init_settings_(DriverSuper* p_super
 
   // streamは0のみ
   stream_config = &(p_super->stream_config[STIM210_STREAM_TLM_CMD]);
+
+  DSC_set_rx_buffer_size_in_if_rx(p_super, DS_IF_RX_BUFFER_SIZE_STIM210);
+
   DSSC_enable(stream_config);
 
   // 定期的な受信はするがフォーマットによって異なるので、STIM210_set_rec_frame_size_で設定する

--- a/src/src_user/Drivers/Aocs/stim210.h
+++ b/src/src_user/Drivers/Aocs/stim210.h
@@ -13,7 +13,7 @@
 #include <src_user/Library/physical_constants.h>
 #include <src_user/Library/quaternion.h>
 
-#define DS_IF_RX_BUFFER_SIZE_STIM210 (16)  //!< IF_RXのバッファサイズ
+#define DS_IF_RX_BUFFER_SIZE_STIM210 (32)  //!< IF_RXのバッファサイズ
 
 /**
  * @enum   STIM210_OPERATION_MODE

--- a/src/src_user/Drivers/Aocs/stim210.h
+++ b/src/src_user/Drivers/Aocs/stim210.h
@@ -13,6 +13,8 @@
 #include <src_user/Library/physical_constants.h>
 #include <src_user/Library/quaternion.h>
 
+#define DS_IF_RX_BUFFER_SIZE_STIM210 (16)  //!< IF_RXのバッファサイズ
+
 /**
  * @enum   STIM210_OPERATION_MODE
  * @brief  STIM210の運用モード

--- a/src/src_user/Drivers/Cdh/fm25v10.c
+++ b/src/src_user/Drivers/Cdh/fm25v10.c
@@ -206,8 +206,10 @@ static DS_ERR_CODE FM25V10_load_driver_super_init_settings_(DriverSuper* super)
   super->interface = SPI;
 
   stream_config = &(super->stream_config[FM25V10_STREAM_TLM_CMD]);
-  DSSC_enable(stream_config);
 
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_IF_RX_BUFFER_SIZE_FM25V10);
+
+  DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, FM25V10_MAX_LENGTH);  // 可変だがサイズ情報なし, 都度設定する
   DSSC_set_data_analyzer(stream_config, FM25V10_analyze_rec_data_);
 

--- a/src/src_user/Drivers/Cdh/fm25v10.h
+++ b/src/src_user/Drivers/Cdh/fm25v10.h
@@ -11,6 +11,9 @@
 
 #define FM25V10_STOP_ADDRESS (0x20000) //!< FM25V10のSTOPアドレス(排他範囲)
 #define FM25V10_MAX_LENGTH  (128)      //!< 読み書きする最大データ数（実行速度などで決める）
+
+#define DS_IF_RX_BUFFER_SIZE_FM25V10 (128)  //!< IF_RXのバッファサイズ
+
 /**
  * @struct FM25V10_Info
  * @brief  FM25V10のテレメトリ情報

--- a/src/src_user/Drivers/Etc/mobc.c
+++ b/src/src_user/Drivers/Etc/mobc.c
@@ -55,6 +55,8 @@ static DS_ERR_CODE MOBC_load_driver_super_init_settings_(DriverSuper* p_super)
   CTCP_init_dssc(p_stream_config, MOBC_tx_frame_, sizeof(MOBC_tx_frame_), MOBC_analyze_rec_data_);
   // 定期TLMの監視機能の有効化しない → ので設定上書きなし
 
+  DSC_set_rx_buffer_size_in_if_rx(p_super, DS_IF_RX_BUFFER_SIZE_MOBC);
+
   DSSC_enable(p_stream_config);
 
   return DS_ERR_CODE_OK;

--- a/src/src_user/Drivers/Etc/mobc.h
+++ b/src/src_user/Drivers/Etc/mobc.h
@@ -12,6 +12,7 @@
 #include <src_core/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h>
 #include <src_core/TlmCmd/packet_handler.h>
 
+// TODO: バッファサイズの最適化（https://github.com/ut-issl/c2a-aobc/pull/161#discussion_r1286204776）
 #define DS_IF_RX_BUFFER_SIZE_MOBC (128)  //!< IF_RXのバッファサイズ
 
 /**

--- a/src/src_user/Drivers/Etc/mobc.h
+++ b/src/src_user/Drivers/Etc/mobc.h
@@ -12,6 +12,8 @@
 #include <src_core/Drivers/Protocol/common_tlm_cmd_packet_for_driver_super.h>
 #include <src_core/TlmCmd/packet_handler.h>
 
+#define DS_IF_RX_BUFFER_SIZE_MOBC (128)  //!< IF_RXのバッファサイズ
+
 /**
  * @enum   MOBC_TX_ERR_CODE
  * @brief  MOBCのコマンド送信（MOBCからみたらテレメ）エラーコード

--- a/src/src_user/Drivers/Power/ina260.c
+++ b/src/src_user/Drivers/Power/ina260.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 #include <src_core/Library/print.h>
+#include <src_user/Settings/DriverSuper/driver_buffer_define.h>
 
 #define INA260_STREAM_TLM_CMD  (0)
 #define INA260_RX_FRAME_SIZE   (2)
@@ -197,8 +198,10 @@ static DS_ERR_CODE INA260_load_driver_super_init_settings_(DriverSuper* super)
   super->interface = I2C;
 
   stream_config = &(super->stream_config[INA260_STREAM_TLM_CMD]);
-  DSSC_enable(stream_config);
 
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+
+  DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, INA260_RX_FRAME_SIZE);
   DSSC_set_data_analyzer(stream_config, INA260_analyze_rec_data_);
 

--- a/src/src_user/Drivers/Power/ina260.c
+++ b/src/src_user/Drivers/Power/ina260.c
@@ -199,7 +199,7 @@ static DS_ERR_CODE INA260_load_driver_super_init_settings_(DriverSuper* super)
 
   stream_config = &(super->stream_config[INA260_STREAM_TLM_CMD]);
 
-  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_I2C);
+  DSC_set_rx_buffer_size_in_if_rx(super, DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL);
 
   DSSC_enable(stream_config);
   DSSC_set_rx_frame_size(stream_config, INA260_RX_FRAME_SIZE);

--- a/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -7,10 +7,9 @@
 
 #include "./driver_super_params.h"
 
-#define DS_STREAM_REC_BUFFER_SIZE_DEFAULT  (DS_IF_RX_BUFFER_SIZE * 2)  /*!< DS_StreamRecBuffer のバッファサイズのデフォルト値
-                                                                            UART などの非同期通信はメモリに余力があれば DS_IF_RX_BUFFER_SIZE * 2 を推奨
-                                                                            詳細は driver_super.c の @note を参照 */
-#define DS_STREAM_REC_BUFFER_SIZE_I2C      (16)                        /*!< DS_StreamRecBuffer のバッファサイズのI2C用
-                                                                            I2Cのやり取りでは、数バイトのlengthなので、余裕分含む */
+#define DS_STREAM_REC_BUFFER_SIZE_DEFAULT            (DS_IF_RX_BUFFER_SIZE * 2)  /*!< DS_StreamRecBuffer のバッファサイズのデフォルト値
+                                                                                      UART などの非同期通信はメモリに余力があれば DS_IF_RX_BUFFER_SIZE * 2 を推奨
+                                                                                      詳細は driver_super.c の @note を参照 */
+#define DS_STREAM_REC_BUFFER_SIZE_SYNCHRONOUS_SMALL  (16)                        /*!< 少データ量同期通信用の DS_StreamRecBuffer のバッファサイズのデフォルト値 */
 
 #endif

--- a/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -10,7 +10,7 @@
 #define DS_STREAM_REC_BUFFER_SIZE_DEFAULT  (DS_IF_RX_BUFFER_SIZE * 2)  /*!< DS_StreamRecBuffer のバッファサイズのデフォルト値
                                                                             UART などの非同期通信はメモリに余力があれば DS_IF_RX_BUFFER_SIZE * 2 を推奨
                                                                             詳細は driver_super.c の @note を参照 */
-#define DS_STREAM_REC_BUFFER_SIZE_I2C      (16 * 2)                    /*!< DS_StreamRecBuffer のバッファサイズのI2C用
+#define DS_STREAM_REC_BUFFER_SIZE_I2C      (16)                        /*!< DS_StreamRecBuffer のバッファサイズのI2C用
                                                                             I2Cのやり取りでは、数バイトのlengthなので、余裕分含む */
 
 #endif

--- a/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -9,6 +9,6 @@
 
 #define DS_STREAM_REC_BUFFER_SIZE_DEFAULT  (DS_IF_RX_BUFFER_SIZE * 2)  /*!< DS_StreamRecBuffer のバッファサイズのデフォルト値
                                                                             UART などの非同期通信はメモリに余力があれば DS_IF_RX_BUFFER_SIZE * 2 を推奨
-                                                                            詳細は dirver_super.c の @note を参照 */
+                                                                            詳細は driver_super.c の @note を参照 */
 
 #endif

--- a/src/src_user/Settings/DriverSuper/driver_buffer_define.h
+++ b/src/src_user/Settings/DriverSuper/driver_buffer_define.h
@@ -10,5 +10,7 @@
 #define DS_STREAM_REC_BUFFER_SIZE_DEFAULT  (DS_IF_RX_BUFFER_SIZE * 2)  /*!< DS_StreamRecBuffer のバッファサイズのデフォルト値
                                                                             UART などの非同期通信はメモリに余力があれば DS_IF_RX_BUFFER_SIZE * 2 を推奨
                                                                             詳細は driver_super.c の @note を参照 */
+#define DS_STREAM_REC_BUFFER_SIZE_I2C      (16 * 2)                    /*!< DS_StreamRecBuffer のバッファサイズのI2C用
+                                                                            I2Cのやり取りでは、数バイトのlengthなので、余裕分含む */
 
 #endif

--- a/src/src_user/Settings/DriverSuper/driver_super_params.h
+++ b/src/src_user/Settings/DriverSuper/driver_super_params.h
@@ -11,7 +11,7 @@
 #define DS_STREAM_MAX         (1)
 
 // TODO: 適切な値を考える
-// Sagittaに合わせて144から350に変更した
+// 最大であるSagittaのテレメに合わせて350byteとしている
 #define DS_IF_RX_BUFFER_SIZE  (350)
 
 #endif

--- a/src/src_user/Settings/DriverSuper/driver_super_params.h
+++ b/src/src_user/Settings/DriverSuper/driver_super_params.h
@@ -11,7 +11,7 @@
 #define DS_STREAM_MAX         (1)
 
 // TODO: 適切な値を考える
-// Sagittaに合わせて144から343に変更した
-#define DS_IF_RX_BUFFER_SIZE  (343)
+// Sagittaに合わせて144から350に変更した
+#define DS_IF_RX_BUFFER_SIZE  (350)
 
 #endif

--- a/src/src_user/Settings/DriverSuper/driver_super_params.h
+++ b/src/src_user/Settings/DriverSuper/driver_super_params.h
@@ -11,7 +11,7 @@
 #define DS_STREAM_MAX         (1)
 
 // TODO: 適切な値を考える
-// OEM7600Driverに合わせて64から144に変更した
-#define DS_IF_RX_BUFFER_SIZE  (144)
+// Sagittaに合わせて144から343に変更した
+#define DS_IF_RX_BUFFER_SIZE  (343)
 
 #endif


### PR DESCRIPTION
## Issue
- #39 

## 詳細
メモリの余裕を生むため，INAなどテレメ量が小さなものはバッファサイズを縮小し，逆にSTTなどテレメを増やしたいものは増やす。

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [x] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果
![image](https://github.com/ut-issl/c2a-aobc/assets/103401287/54b6bfd9-2a3e-4e56-b3af-165dbce5ce29)
テレメについてはMOBC以外をSILSで確認，MPUやRM，FRAMなどEMに接続されているコンポをEMで確認済み。

## 補足
STTのテレメについては #137 を参照のこと。
また，これのマージ後に #159 に対応する。

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
