### PR TITLE
STTのフッター修正

### DIFF
--- a/src/src_user/Drivers/Aocs/sagitta.c
+++ b/src/src_user/Drivers/Aocs/sagitta.c
@@ -1118,9 +1118,9 @@ static int SAGITTA_set_tx_frame_xxhash_(uint8_t cmd_data_len)
 
 static int SAGITTA_set_tx_frame_footer_(uint8_t cmd_offset_len)
 {
-  for (uint8_t i = cmd_offset_len; i < cmd_offset_len + SAGITTA_FOOTER_SIZE; i++)
+  for (uint8_t i = 0; i < SAGITTA_FOOTER_SIZE; i++)
   {
-    SAGITTA_tx_frame_[i] = SAGITTA_kFooter_[i];
+    SAGITTA_tx_frame_[cmd_offset_len + i] = SAGITTA_kFooter_[i];
   }
   return SAGITTA_FOOTER_SIZE;
 }


### PR DESCRIPTION
## Issue
#74 

## 詳細
issueに記載

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [x] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
#### SILS
- 修正前
<img width="1071" alt="スクリーンショット 2023-08-14 15 51 51" src="https://github.com/ut-issl/c2a-aobc/assets/82629762/71edc7ac-950e-4a2e-be9a-eb3738a462fa">

- 修正後
<img width="1075" alt="スクリーンショット 2023-08-14 15 52 28" src="https://github.com/ut-issl/c2a-aobc/assets/82629762/90b5e495-544e-4bb0-8d56-382a91e93ed8">

#### 実機
実機では、indexがおかしい修正前から、footerが0xc0に設定できていた。念の為、修正後も1つ目のコマンドからきちんとfooterが設定できていることを確認。（修正前の状態でfooterを変更すると、コマンドもおかしくなる。つまり、`SAGITTA_kFooter_`は使われているが、indexはたまたま影響しない状況だった）。
```
c0 21 03 01    01 9c 34 9a    61 c0
```

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
