### PR TITLE
Remove compile-time calculation

### DIFF
--- a/src/src_user/Library/Orbit/sgp4.c
+++ b/src/src_user/Library/Orbit/sgp4.c
@@ -16,7 +16,7 @@
 #include <src_core/Library/print.h>
 
 // SGP4内での使う定数
-static const float SGP4_kKe_s = sqrtf(PHYSICAL_CONST_EARTH_GRAVITY_CONST_km3_s2 / powf(PHYSICAL_CONST_EARTH_RADIUS_km, 3.0f));
+static const float SGP4_kKe_s = 0.00123945f;       //!< sqrtf(PHYSICAL_CONST_EARTH_GRAVITY_CONST_km3_s2 / powf(PHYSICAL_CONST_EARTH_RADIUS_km, 3.0f));
 static const float SGP4_kDensityFunc = 1.012229f;  //!< 密度関数パラメータ s
 static const float SGP4_kQMS4 = 1.880279e-9f;      //!< (q - s)^4
 


### PR DESCRIPTION
## Issue
- NA

## 詳細
- C++ および gcc 拡張のコンパイル時計算を用いていたコードがあったので，事前計算した即値に切り替えた
- これで `BUILD_C2A_AS_CXX=OFF` かつ clang でのビルドが通るようになる

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 図や表で記述する

## 補足
vmicro を廃止する際に，実機での `libC2A.a` のビルドは `BUILD_C2A_AS_CXX=OFF` を想定している