### PR TITLE
Build as C++ option should default OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(C2A)
 
-option(BUILD_C2A_AS_CXX "Build C2A as C++" ON)
+option(BUILD_C2A_AS_CXX "Build C2A as C++" OFF)
 
 option(BUILD_C2A_AS_SILS_FW "Build C2A as SILS firmware" ON)
 


### PR DESCRIPTION
## Issue
NA

## 詳細
- c2a-aobc 全体を C++ としてビルドするのは SILS-S2E のときのみであり，default ON であるべきではないため，default OFF にする
- この変更により，c2a-aobc と組み合わせる S2E user では明示的に `BUILD_C2A_AS_CXX=ON` にする必要がある
  - これは既に多くの S2E user で行われており，[s2e-aobc でもそのようになっている](https://github.com/ut-issl/s2e-aobc/blob/7be60ce4d697f52ad81d2fea1391cc3ba35b0c7b/CMakeLists.txt#L50) ため，breaking change ではないものとする

## 検証結果
### ビルドチェック (どちらもチェック)
- [ ] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

## 補足
- workflows-c2a での C および C++ での CI では `BUILD_C2A_AS_CXX` はビルド時に明示的に指定しているため影響はない
- 今後実機向けのビルドも CMake で行うようにしていくが，その時は `IfWrapper/Arduino` 以外は C としてビルドしたい