### PR TITLE
Expand DI buffer for STT

### DIFF
--- a/src/src_user/Settings/DriverSuper/driver_super_params.h
+++ b/src/src_user/Settings/DriverSuper/driver_super_params.h
@@ -11,7 +11,7 @@
 #define DS_STREAM_MAX         (1)
 
 // TODO: 適切な値を考える
-// 最大であるSagittaのテレメに合わせて350byteとしている
-#define DS_IF_RX_BUFFER_SIZE  (350)
+// 最大であるSagittaのテレメに合わせて368byteとしている
+#define DS_IF_RX_BUFFER_SIZE  (368)
 
 #endif


### PR DESCRIPTION
## Issue
- #39 

## 詳細
増やしたSTTのテレメに合わせ，バッファサイズを増やした

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- バッファを増やす側の修正なので，これまで動作していた部分は問題なく動作する
- 実際にSTTのテレメエラーがどれだけ減るかの検証は星が取れないと難しいので行わない

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- ビルドの際のRAM使用量は 117884 byte から 117936 byte に増加した

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
