### PR TITLE
sagitta driver で厳密なフレーム探索を有効化

### DIFF
--- a/src/src_user/Drivers/Aocs/sagitta.c
+++ b/src/src_user/Drivers/Aocs/sagitta.c
@@ -1098,9 +1098,11 @@ static DS_ERR_CODE SAGITTA_load_driver_super_init_settings_(DriverSuper* p_super
 
   stream_config = &(p_super->stream_config[SAGITTA_STREAM_TLM_CMD]);
   DSSC_enable(stream_config);
+  DSSC_enable_strict_frame_search(stream_config); // ヘッダとフッタの文字列が共通しており，テレメ長ものっていないので，フレーム確定に失敗しやすいため
 
+  // 送信側
   DSSC_set_tx_frame(stream_config, SAGITTA_tx_frame_);
-  DSSC_set_tx_frame_size(stream_config, SAGITTA_tx_frame_length_);
+  DSSC_set_tx_frame_size(stream_config, 0); // 送る直前に値をセットする
 
   // 定期的な受信はする
   DSSC_set_rx_header(stream_config, SAGITTA_kRxHeader_, SAGITTA_RX_HEADER_SIZE);

--- a/src/src_user/Drivers/Aocs/sagitta.c
+++ b/src/src_user/Drivers/Aocs/sagitta.c
@@ -222,8 +222,6 @@ DS_REC_ERR_CODE SAGITTA_rec(SAGITTA_Driver* sagitta_driver)
   DS_ERR_CODE ret;
   DS_StreamConfig* stream_config;
 
-  DS_clear_rx_buffer(&(sagitta_driver->driver.super)); // ここでクリアしないとずれる
-
   ret = DS_receive(&(sagitta_driver->driver.super));
 
 #ifdef DRIVER_SAGITTA_DEBUG_SHOW_REC_DATA


### PR DESCRIPTION
## Issue
- https://github.com/ut-issl/6u-aocs-task/issues/48

## 詳細
- sagitta driverで [これ](https://github.com/ut-issl/c2a-core/blob/develop/Drivers/Super/driver_super.h#L287-L297) を有効化した

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 図や表で記述する

## 補足
N/A

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
