### PR TITLE
Build as C99 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ set(C2A_CORE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/src_core)
 set(C2A_USER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/src_user)
 set(C2A_SATELLITE_PARAMETERS_DIR SatelliteParameters/Sample) # relative path from Settings
 
+if(NOT BUILD_C2A_AS_CXX)
+  set(BUILD_C2A_AS_C99 ON)
+endif()
 set(USE_ALL_C2A_CORE_APPS OFF)
 set(USE_ALL_C2A_CORE_TEST_APPS OFF)
 set(USE_ALL_C2A_CORE_LIB ON)

--- a/src/src_user/common.cmake
+++ b/src/src_user/common.cmake
@@ -1,5 +1,8 @@
 if(BUILD_C2A_AS_CXX)
   set_source_files_properties(${C2A_SRCS} PROPERTIES LANGUAGE CXX)
+else()
+  set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99)
+  set_target_properties(${PROJECT_NAME} PROPERTIES C_EXTENSIONS FALSE) # no extensions(GNU)
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC SILS_FW)


### PR DESCRIPTION
## 詳細
この C2A user は C89 としてビルドする必要が全くないので，デフォルト（`BUILD_AS_CXX` ≒ SILS-S2E でないとき）で C99 としてビルドするようにする

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

## 補足
何かあれば書く。なければ`NA`とする。

