### PR TITLE
[Hotfix] Fix SS state check

### DIFF
--- a/src/src_user/Applications/DriverInstances/di_nanossoc_d60.c
+++ b/src/src_user/Applications/DriverInstances/di_nanossoc_d60.c
@@ -98,7 +98,7 @@ static void DI_NANOSSOC_D60_update_(void)
     EL_record_event(EL_GROUP_TLM_ERROR_NANOSSOC, (uint32_t)NANOSSOC_D60_idx_counter_, EL_ERROR_LEVEL_HIGH, (uint32_t)ret);
   }
 
-  NANOSSOC_D60_CHECKSUM_STATE state = nanossoc_d60_driver_->info.checksum_state;
+  NANOSSOC_D60_CHECKSUM_STATE state = nanossoc_d60_driver_[NANOSSOC_D60_idx_counter_].info.checksum_state;
   if (state != NANOSSOC_D60_CHECKSUM_STATE_OK)
   {
     EL_record_event(EL_GROUP_ERROR_NANOSSOC, (uint32_t)NANOSSOC_D60_idx_counter_, EL_ERROR_LEVEL_HIGH, (uint32_t)NANOSSOC_D60_EL_NOTE_CHECKSUM_ERROR);


### PR DESCRIPTION
## Issue
#167 

## 詳細
本来はchecksum判定のときにSS idx指定をすべきだができていなかったので修正した。

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った -> 微修正なので必要ないかな

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
正しく値が入ることを確認した

<img width="1341" alt="image" src="https://github.com/ut-issl/c2a-aobc/assets/19573779/132efce8-d8a6-4131-852c-a355dbb2d9d6">


## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
