### PR TITLE
Update s2e-aobc version to v5.0.0 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   # renovate: datasource=github-releases depName=ut-issl/s2e-aobc
-  S2E_AOBC_VERSION: v4.0.0
+  S2E_AOBC_VERSION: v5.0.0
 
 jobs:
   build_c2a_with_s2e_win:


### PR DESCRIPTION
## Issue
#231 

## 詳細
s2e-aobc v5.0.0がリリースされたので、CIで参照するバージョンを更新する。


## 検証結果
CI結果を確認する。

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
