### PR TITLE
add ss check by degree

### DIFF
--- a/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/SensorSelectors/sun_sensor_selector.c
+++ b/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/SensorSelectors/sun_sensor_selector.c
@@ -15,9 +15,6 @@
 // Satellite Parameters
 #include <src_user/Settings/SatelliteParameters/nanossoc_d60_parameters.h>
 
-#define NANOSSOC_D60_UPPER_LIMIT_ANGLE_DEGREE (60)  //!< コンポ検出上限
-#define NANOSSOC_D60_LOWER_LIMIT_ANGLE_DEGREE (-60) //!< コンポ検出下限
-
 static SunSensorSelector        sun_sensor_selector_;
 const  SunSensorSelector* const sun_sensor_selector = &sun_sensor_selector_;
 

--- a/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/SensorSelectors/sun_sensor_selector.c
+++ b/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/SensorSelectors/sun_sensor_selector.c
@@ -15,6 +15,9 @@
 // Satellite Parameters
 #include <src_user/Settings/SatelliteParameters/nanossoc_d60_parameters.h>
 
+#define NANOSSOC_D60_UPPER_LIMIT_ANGLE_DEGREE (60)  //!< コンポ検出上限
+#define NANOSSOC_D60_LOWER_LIMIT_ANGLE_DEGREE (-60) //!< コンポ検出下限
+
 static SunSensorSelector        sun_sensor_selector_;
 const  SunSensorSelector* const sun_sensor_selector = &sun_sensor_selector_;
 
@@ -109,6 +112,8 @@ static void APP_SS_SELECTOR_generate_available_list_(void)
 static APP_SS_SELECTOR_AVAILABLE APP_SS_SELECTOR_check_availability_(NANOSSOC_D60_IDX idx)
 {
   float sun_intensity_percent = nanossoc_d60_driver[idx]->info.sun_intensity_percent;
+  float sun_angle_compo_alpha_deg = nanossoc_d60_driver[idx]->info.sun_angle_compo_deg[NANOSSOC_D60_ANGLE_ELEMENT_ALPHA];
+  float sun_angle_compo_beta_deg = nanossoc_d60_driver[idx]->info.sun_angle_compo_deg[NANOSSOC_D60_ANGLE_ELEMENT_BETA];
 
   if (nanossoc_d60_driver[idx]->info.checksum_state != NANOSSOC_D60_CHECKSUM_STATE_OK)
   {
@@ -119,6 +124,14 @@ static APP_SS_SELECTOR_AVAILABLE APP_SS_SELECTOR_check_availability_(NANOSSOC_D6
     return APP_SS_SELECTOR_AVAILABLE_NG;
   }
   else if (sun_intensity_percent > sun_sensor_selector->sun_intensity_upper_threshold_percent)
+  {
+    return APP_SS_SELECTOR_AVAILABLE_NG;
+  }
+  else if (sun_angle_compo_alpha_deg <= NANOSSOC_D60_LOWER_LIMIT_ANGLE_DEGREE || NANOSSOC_D60_UPPER_LIMIT_ANGLE_DEGREE <= sun_angle_compo_alpha_deg)
+  {
+    return APP_SS_SELECTOR_AVAILABLE_NG;
+  }
+  else if (sun_angle_compo_beta_deg <= NANOSSOC_D60_LOWER_LIMIT_ANGLE_DEGREE || NANOSSOC_D60_UPPER_LIMIT_ANGLE_DEGREE <= sun_angle_compo_beta_deg)
   {
     return APP_SS_SELECTOR_AVAILABLE_NG;
   }

--- a/src/src_user/Drivers/Aocs/nanossoc_d60.h
+++ b/src/src_user/Drivers/Aocs/nanossoc_d60.h
@@ -11,8 +11,8 @@
 #include <src_user/Library/quaternion.h>
 #include <src_user/Library/physical_constants.h>
 
-#define NANOSSOC_D60_UPPER_LIMIT_ANGLE_DEGREE (60)  //!< コンポ検出上限
-#define NANOSSOC_D60_LOWER_LIMIT_ANGLE_DEGREE (-60) //!< コンポ検出下限
+#define NANOSSOC_D60_UPPER_LIMIT_ANGLE_DEGREE (60.0f)	//!< 検出上限角度
+#define NANOSSOC_D60_LOWER_LIMIT_ANGLE_DEGREE (-60.0f) 	//!< 検出下限角度
 
 /**
 * @enum  NANOSSOC_D60_ErrorCode

--- a/src/src_user/Drivers/Aocs/nanossoc_d60.h
+++ b/src/src_user/Drivers/Aocs/nanossoc_d60.h
@@ -11,6 +11,9 @@
 #include <src_user/Library/quaternion.h>
 #include <src_user/Library/physical_constants.h>
 
+#define NANOSSOC_D60_UPPER_LIMIT_ANGLE_DEGREE (60)  //!< コンポ検出上限
+#define NANOSSOC_D60_LOWER_LIMIT_ANGLE_DEGREE (-60) //!< コンポ検出下限
+
 /**
 * @enum  NANOSSOC_D60_ErrorCode
 * @brief 太陽検出率および角度出力に応じたエラーコード

--- a/src/src_user/Drivers/Aocs/nanossoc_d60.h
+++ b/src/src_user/Drivers/Aocs/nanossoc_d60.h
@@ -11,8 +11,8 @@
 #include <src_user/Library/quaternion.h>
 #include <src_user/Library/physical_constants.h>
 
-#define NANOSSOC_D60_UPPER_LIMIT_ANGLE_DEGREE (60.0f)	//!< 検出上限角度
-#define NANOSSOC_D60_LOWER_LIMIT_ANGLE_DEGREE (-60.0f) 	//!< 検出下限角度
+#define NANOSSOC_D60_UPPER_LIMIT_ANGLE_DEGREE (60.0f)  //!< 検出上限角度
+#define NANOSSOC_D60_LOWER_LIMIT_ANGLE_DEGREE (-60.0f) //!< 検出下限角度
 
 /**
 * @enum  NANOSSOC_D60_ErrorCode


### PR DESCRIPTION
## 詳細
太陽センサーの有効判定に以下を追加
　・-60度＜alpha＜60度
　・-60度＜beta＜60度

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

## 補足
NA