### PR TITLE
fix bug PIC INA read error

### DIFF
--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_ina260.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_ina260.c
@@ -25,6 +25,14 @@ void BCL_load_power_on_ina260()
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_APP_PSC_CONTROL_5V_PORT);
   bc_cycle += OBCT_sec2cycle(1);
 
+  // Dummy initialize(for bug fix)
+  BCL_tool_prepare_param_uint8(INA260_IDX_PIC);
+  BCL_tool_prepare_param_uint8(INA260_PARAMETERS_pic_averaging_mode);
+  BCL_tool_prepare_param_uint8(INA260_PARAMETERS_pic_voltage_conversion_time);
+  BCL_tool_prepare_param_uint8(INA260_PARAMETERS_pic_current_conversion_time);
+  BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_INA260_INIT);
+  bc_cycle++;
+
   // Initialize
   BCL_tool_prepare_param_uint8(INA260_IDX_PIC);
   BCL_tool_prepare_param_uint8(INA260_PARAMETERS_pic_averaging_mode);


### PR DESCRIPTION
## Issue
[#252](https://github.com/ut-issl/c2a-aobc/issues/252)

## 詳細
本来のINA260初期化コマンドの直前にダミーとして1つ初期化コマンドを挿入する。
これにより本来のINA260初期化コマンドは成功するようになる。

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [x] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果
NG事象が再現する2枚の基板共、本対策で再現しなくなった。

## 補足
NA
