### PR TITLE
IGRF計算の修正

### DIFF
--- a/src/src_user/Library/geomagnetism.c
+++ b/src/src_user/Library/geomagnetism.c
@@ -264,8 +264,6 @@ C2A_MATH_ERROR GEOMAGNETISM_calc_igrf(float* mag_i_nT, const uint8_t clac_order,
   double legendre_p_n_2[GEOMAGNETISM_IGRF_ORDER_MAX + 1];  //!< P[n-2][m]
   double legendre_p_n_1[GEOMAGNETISM_IGRF_ORDER_MAX + 1];  //!< P[n-1][m]
   double legendre_dp_n_1_n_1  = 0.0;                       //!< dP[n-1][n-1]
-  //float sin_colat = sinf(colat_rad);
-  //float cos_colat = cosf(colat_rad);
   double sin_colat = sin((double)(colat_rad));
   double cos_colat = cos((double)(colat_rad));
 

--- a/src/src_user/Library/geomagnetism.c
+++ b/src/src_user/Library/geomagnetism.c
@@ -205,12 +205,12 @@ static void GEOMAGNETISM_calc_trigonometric_(float sinn[GEOMAGNETISM_IGRF_ORDER_
                                               const uint8_t order);
 
 //!< ルジャンドル陪関数の各係数の計算
-static void GEOMAGNETISM_calc_legendre_coeffs_(float pn[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
-                                               float dpn[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
-                                               float pn_1[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
-                                               float pn_2[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
-                                               float* dpn_1n_1,
-                                               const float sinl, const float cosl,
+static void GEOMAGNETISM_calc_legendre_coeffs_(double pn[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
+                                               double dpn[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
+                                               double pn_1[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
+                                               double pn_2[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
+                                               double* dpn_1n_1,
+                                               const double sinl, const double cosl,
                                                const uint8_t order);
 
 
@@ -259,13 +259,15 @@ C2A_MATH_ERROR GEOMAGNETISM_calc_igrf(float* mag_i_nT, const uint8_t clac_order,
   GEOMAGNETISM_calc_trigonometric_(sin_m, cos_m, lon_rad, order);
 
   //!< buffer to solve the recurrence equation
-  float legendre_p_n[GEOMAGNETISM_IGRF_ORDER_MAX + 1];    //!< P[n][m]
-  float legendre_dp_n[GEOMAGNETISM_IGRF_ORDER_MAX + 1];   //!< dP[n][m]
-  float legendre_p_n_2[GEOMAGNETISM_IGRF_ORDER_MAX + 1];  //!< P[n-2][m]
-  float legendre_p_n_1[GEOMAGNETISM_IGRF_ORDER_MAX + 1];  //!< P[n-1][m]
-  float legendre_dp_n_1_n_1  = 0.0f;                      //!< dP[n-1][n-1]
-  float sin_colat = sinf(colat_rad);
-  float cos_colat = cosf(colat_rad);
+  double legendre_p_n[GEOMAGNETISM_IGRF_ORDER_MAX + 1];    //!< P[n][m]
+  double legendre_dp_n[GEOMAGNETISM_IGRF_ORDER_MAX + 1];   //!< dP[n][m]
+  double legendre_p_n_2[GEOMAGNETISM_IGRF_ORDER_MAX + 1];  //!< P[n-2][m]
+  double legendre_p_n_1[GEOMAGNETISM_IGRF_ORDER_MAX + 1];  //!< P[n-1][m]
+  double legendre_dp_n_1_n_1  = 0.0;                       //!< dP[n-1][n-1]
+  //float sin_colat = sinf(colat_rad);
+  //float cos_colat = cosf(colat_rad);
+  double sin_colat = sin((double)(colat_rad));
+  double cos_colat = cos((double)(colat_rad));
 
   //!< geomagnetic coefficients
   float gnm[GEOMAGNETISM_IGRF_ORDER_MAX + 1];
@@ -290,9 +292,9 @@ C2A_MATH_ERROR GEOMAGNETISM_calc_igrf(float* mag_i_nT, const uint8_t clac_order,
     float mag_ned_temp[PHYSICAL_CONST_THREE_DIM] = { 0.0f, 0.0f, 0.0f };
     for (uint8_t m = 0; m <= n; m++)
     {
-      mag_ned_temp[0] += (gnm[m] * cos_m[m] + hnm[m] * sin_m[m]) * legendre_dp_n[m];
-      mag_ned_temp[1] += (float)(m) * (gnm[m] * sin_m[m] - hnm[m] * cos_m[m]) * legendre_p_n[m];
-      mag_ned_temp[2] += - (gnm[m] * cos_m[m] + hnm[m] * sin_m[m]) * legendre_p_n[m];
+      mag_ned_temp[0] += (gnm[m] * cos_m[m] + hnm[m] * sin_m[m]) * (float)(legendre_dp_n[m]);
+      mag_ned_temp[1] += (float)(m) * (gnm[m] * sin_m[m] - hnm[m] * cos_m[m]) * (float)(legendre_p_n[m]);
+      mag_ned_temp[2] += - (gnm[m] * cos_m[m] + hnm[m] * sin_m[m]) * (float)(legendre_p_n[m]);
     }
 
     mag_ned_nT[0] += pow_k_geo_aspect * mag_ned_temp[0];
@@ -347,15 +349,15 @@ static void GEOMAGNETISM_calc_trigonometric_(float sinn[GEOMAGNETISM_IGRF_ORDER_
 }
 
 
-static void GEOMAGNETISM_calc_legendre_coeffs_(float p_n[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
-                                               float dp_n[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
-                                               float p_n_1[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
-                                               float p_n_2[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
-                                               float* dp_n_1_n_1,
-                                               const float sinl, const float cosl,
+static void GEOMAGNETISM_calc_legendre_coeffs_(double p_n[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
+                                               double dp_n[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
+                                               double p_n_1[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
+                                               double p_n_2[GEOMAGNETISM_IGRF_ORDER_MAX + 1],
+                                               double* dp_n_1_n_1,
+                                               const double sinl, const double cosl,
                                                const uint8_t order)
 {
-  uint8_t n = order;
+  uint64_t n = (uint64_t)(order); // 桁的にはuint8で十分だが，doubleにキャストする際のwarningを避けるためにuint64にする
 
   if (n == 1)
   {
@@ -374,22 +376,22 @@ static void GEOMAGNETISM_calc_legendre_coeffs_(float p_n[GEOMAGNETISM_IGRF_ORDER
   }
 
   // P(n,n) = (2n-1)*(sin_l)*P(n-1,n-1)
-  p_n[n]  = (float)(2 * n - 1) * sinl * p_n_1[n - 1];
+  p_n[n]  = (double)(2 * n - 1) * sinl * p_n_1[n - 1];
 
   // P(n,0) = (1/n)*[(2n-1)*(cos_l)*P(n-1,0) - (n-1)*P(n-2,0)]
-  p_n[0]  = (1.0f / (float)(n)) * ((float)(2 * n - 1) * cosl * p_n_1[0] - (float)(n - 1) * p_n_2[0]);
+  p_n[0]  = (1.0f / (double)(n)) * ((double)(2 * n - 1) * cosl * p_n_1[0] - (double)(n - 1) * p_n_2[0]);
 
-  for (uint8_t m = 1; m < n; m++)
+  for (uint64_t m = 1; m < n; m++)
   {
     if (fabsf(sinl) > GEOMAGNETISM_POLAR_REGION_SIN_COLAT_LIMIT)
     {
       // P(n,m) = [(n+m-1)*P(n-1,m-1) - (n-m+1)*cos_l*P(n,m-1)]/sin_l
-      p_n[m] = ((float)(n + m - 1) * p_n_1[m - 1] - (float)(n - m + 1) * cosl * p_n[m - 1]) / sinl;
+      p_n[m] = ((double)(n + m - 1) * p_n_1[m - 1] - (double)(n - m + 1) * cosl * p_n[m - 1]) / sinl;
     }
     else
     {
       // P(n,m) = [P(n-1,m) + (n-m+1)*sin_l*P(n,m-1)]/cos_l
-      p_n[m] = (p_n_1[m] + (float)(n - m + 1) * sinl * p_n[m - 1]) / cosl;
+      p_n[m] = (p_n_1[m] + (double)(n - m + 1) * sinl * p_n[m - 1]) / cosl;
     }
   }
 
@@ -398,17 +400,17 @@ static void GEOMAGNETISM_calc_legendre_coeffs_(float p_n[GEOMAGNETISM_IGRF_ORDER
 
   // dP(n,n) = (2n-1)*[(cos_l)*P(n-1,n-1) + (sin_l)*dP(n-1,n-1)]
   // (equation in the reference document is incorrect...)
-  dp_n[n] = (float)(2 * n - 1) * (cosl * p_n_1[n - 1] + sinl * (*dp_n_1_n_1));
+  dp_n[n] = (double)(2 * n - 1) * (cosl * p_n_1[n - 1] + sinl * (*dp_n_1_n_1));
 
-  for (uint8_t m = 1; m < n; m++)
+  for (uint64_t m = 1; m < n; m++)
   {
     // dP(n,m) = [(n+m)*(n-m+1)*P(n,m-1) - P(n,m+1)]/2
-    dp_n[m] = 0.5f * ((float)((n + m) * (n - m + 1)) * p_n[m - 1] - p_n[m + 1]);
+    dp_n[m] = 0.5 * ((double)((n + m) * (n - m + 1)) * p_n[m - 1] - p_n[m + 1]);
   }
 
   // swap buffer for the next recurrence equation
-  memcpy(p_n_2, p_n_1, (size_t)(sizeof(float) * (GEOMAGNETISM_IGRF_ORDER_MAX + 1)));
-  memcpy(p_n_1, p_n, (size_t)(sizeof(float) * (GEOMAGNETISM_IGRF_ORDER_MAX + 1)));
+  memcpy(p_n_2, p_n_1, (size_t)(sizeof(double) * (GEOMAGNETISM_IGRF_ORDER_MAX + 1)));
+  memcpy(p_n_1, p_n, (size_t)(sizeof(double) * (GEOMAGNETISM_IGRF_ORDER_MAX + 1)));
   *dp_n_1_n_1 = dp_n[n];
 }
 


### PR DESCRIPTION
## Issue
NA

## 詳細
IGRF計算中のルジャンドル陪関数計算時に，極域付近を通過する場合にはsin_colatの値を基に計算方式を切り替える必要がある．  
切替の閾値はdoubleで書かれた参照元コードの値を用いていたが，変数型をfloatに変更していたため，閾値判定が甘くなり，数値的な安定性が損なわれていた．  
そのため，本修正ではルジャンドル陪関数計算に掛かる変数のみ，変数型をdoubleに変更した．  
修正後のコードにて，数値的に不安定だった経緯度領域での計算結果の安定性が改善されたことを確認した．

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- S2E上にてAOCSマネージャに渡された慣性地磁場方向の計算結果をデバッグモニタすることで検証を実施  
![無題](https://github.com/ut-issl/c2a-aobc/assets/97158519/3eb49277-fb78-4019-9e48-aa0518cbf7eb)  

- vMicroでのbuild結果は下記の通り
![image](https://github.com/ut-issl/c2a-aobc/assets/97158519/c9dd4ba6-6f38-4133-8416-1047ff6e234f)


## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
