### PR TITLE
STTのRXバッファを増やす

### DIFF
--- a/src/src_user/Drivers/Aocs/sagitta.c
+++ b/src/src_user/Drivers/Aocs/sagitta.c
@@ -16,7 +16,7 @@
 
 #define SAGITTA_STREAM_TLM_CMD        (0)
 #define SAGITTA_TX_MAX_FRAME_SIZE     (80)  //!< TXフレームの最大バイト数。
-#define SAGITTA_RX_MAX_FRAME_SIZE     (350) //!< RXフレームの最大バイト数。
+#define SAGITTA_RX_MAX_FRAME_SIZE     (368) //!< RXフレームの最大バイト数。
 
 #define SAGITTA_TX_HEADER_SIZE        (1)  //!< TXのヘッダーのサイズ。
 #define SAGITTA_RX_HEADER_SIZE        (2)  //!< RXのヘッダーのサイズ。


### PR DESCRIPTION
## Issue
#206 

## 詳細
issueおよび下記動作確認チェック参照。

## 検証結果
### ビルドチェック (どちらもチェック)
- [ ] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
368byte程度にすれば、サイズとして十分であることは、リアルスカイ試験のログ解析から確認済み。
バッファサイズは少なくとも1024byteまで大きくしても問題ないことは、stt firmware updateをaobc経由で実施した際に確認済み。
したがって、今回のPRは、vmicroでbuildが通ることのみを確認した。

- [ ] SILSでアルゴリズムが想定通りに動いた
- [x] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
NA

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
