### PR TITLE
磁気センサバイアスの更新

### DIFF
--- a/src/src_user/Settings/SatelliteParameters/Sample/rm3100_parameters.c
+++ b/src/src_user/Settings/SatelliteParameters/Sample/rm3100_parameters.c
@@ -8,7 +8,7 @@
 // AOBC RM3100
 // Magnetometer bias
 // The following parameter should be tuned with magnetic experiment
-const float RM3100_PARAMETERS_mag_aobc_bias_compo_nT[PHYSICAL_CONST_THREE_DIM] = { 32808.59f, -79748.68f, 22059.96f };
+const float RM3100_PARAMETERS_mag_aobc_bias_compo_nT[PHYSICAL_CONST_THREE_DIM] = { 2692.75f, -77195.48f, 25628.46f };
 
 // Magnetometer filter
 // 1st order Low Pass Filter
@@ -26,7 +26,7 @@ const Quaternion RM3100_PARAMETERS_mag_ext_quaternion_c2b = {-0.707106471, 0.707
 
 // Magnetometer bias
 // The following parameter should be tuned with magnetic experiment
-const float RM3100_PARAMETERS_mag_ext_bias_compo_nT[PHYSICAL_CONST_THREE_DIM] = { 36824.97f, -4596.48f,  -1133.40f };
+const float RM3100_PARAMETERS_mag_ext_bias_compo_nT[PHYSICAL_CONST_THREE_DIM] = { 36739.17f, -1727.35f,  3670.1f };
 
 // Magnetometer filter
 // 1st order Low Pass Filter

--- a/src/src_user/Settings/SatelliteParameters/nanossoc_d60_parameters.h
+++ b/src/src_user/Settings/SatelliteParameters/nanossoc_d60_parameters.h
@@ -29,4 +29,8 @@ extern float NANOSSOC_D60_PARAMETERS_spike_filter_config_amplitude_limit_to_acce
 extern float NANOSSOC_D60_PARAMETERS_sun_intensity_lower_threshold_percent; //!< Sun intensity lower threshold [%]
 extern float NANOSSOC_D60_PARAMETERS_sun_intensity_upper_threshold_percent; //!< Sun intensity upper threshold [%]
 
+// Magnetic sensor bias calibration
+extern const float NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[PHYSICAL_CONST_THREE_DIM]; //!< Magnetic sensor bias calibration
+extern const float NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[PHYSICAL_CONST_THREE_DIM]; //!< Magnetic sensor bias calibration
+
 #endif // NANOSSOC_D60_PARAMETERS_H_

--- a/src/src_user/Settings/SatelliteParameters/oem7600_parameters.h
+++ b/src/src_user/Settings/SatelliteParameters/oem7600_parameters.h
@@ -24,4 +24,7 @@ extern uint8_t OEM7600_PARAMETERS_total_gps_time_spike_filter_config_count_limit
 extern double OEM7600_PARAMETERS_total_gps_time_spike_filter_config_reject_threshold_s;                      //!< Reject threshold about gps_time [ms]
 extern double OEM7600_PARAMETERS_total_gps_time_spike_filter_config_amplitude_limit_to_accept_as_step_s;     //!< Amplitude limit to accept as step input about gps_time [ms]
 
+// Magnetic sensor bias calibration
+extern const float OEM7600_PARAMETERS_mag_bias_compo[PHYSICAL_CONST_THREE_DIM]; //!< Magnetic sensor bias calibration
+
 #endif // OEM7600_PARAMETERS_H_

--- a/src/src_user/Settings/SatelliteParameters/sagitta_parameters.h
+++ b/src/src_user/Settings/SatelliteParameters/sagitta_parameters.h
@@ -15,4 +15,7 @@ extern uint8_t SAGITTA_PARAMETERS_q_i2b_spike_filter_config_count_limit_to_rejec
 extern double SAGITTA_PARAMETERS_q_i2b_spike_filter_config_reject_threshold_rad;                     //!< Reject threshold [rad]
 extern double SAGITTA_PARAMETERS_q_i2b_spike_filter_config_amplitude_limit_to_accept_as_step_rad;    //!< Amplitude limit to accept as step input [rad]
 
+// Magnetic sensor bias calibration
+extern const float SAGITTA_PARAMETERS_mag_bias_compo[PHYSICAL_CONST_THREE_DIM]; //!< Magnetic sensor bias calibration
+
 #endif // SAGITTA_PARAMETERS_H_

--- a/src/src_user/Settings/SatelliteParameters/stim210_parameters.h
+++ b/src/src_user/Settings/SatelliteParameters/stim210_parameters.h
@@ -31,4 +31,7 @@ extern const uint8_t STIM210_PARAMETERS_gyro_spike_count_limit_to_reject_continu
 extern const float STIM210_PARAMETERS_gyro_spike_reject_threshold_rad_s[PHYSICAL_CONST_THREE_DIM];                    //!< Reject threshold [rad/s]
 extern const float STIM210_PARAMETERS_gyro_spike_amplitude_limit_to_accept_as_step_rad_s[PHYSICAL_CONST_THREE_DIM];   //!< Amplitude limit to accept as step input [rad/s]
 
+// Magnetic sensor bias calibration
+extern const float STIM210_PARAMETERS_mag_bias_compo[PHYSICAL_CONST_THREE_DIM]; //!< Bias @ component frame X axis
+
 #endif // STIM210_PARAMETERS_H_

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_nanossoc_d60.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_nanossoc_d60.c
@@ -14,6 +14,9 @@
 #include <src_user/Settings/System/EventHandlerRules/event_handler_rules.h>
 #include <src_user/Settings/System/event_logger_group.h>
 
+// Satellite parameters
+#include <src_user/Settings/SatelliteParameters/nanossoc_d60_parameters.h>
+
 void BCL_load_power_on_nanossoc_d60(void)
 {
   cycle_t bc_cycle = OBCT_sec2cycle(1);
@@ -40,18 +43,18 @@ void BCL_load_power_on_nanossoc_d60(void)
 #ifndef SILS_FW // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(28.94f);
-  BCL_tool_prepare_param_float(-17.68f);
-  BCL_tool_prepare_param_float(77.99f);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[0]);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[1]);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(97.61f);
-  BCL_tool_prepare_param_float(-48.16f);
-  BCL_tool_prepare_param_float(44.57f);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[0]);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[1]);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
@@ -105,18 +108,18 @@ void BCL_load_power_off_nanossoc_d60(void)
 #ifndef SILS_FW // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(-28.94f);
-  BCL_tool_prepare_param_float(17.68f);
-  BCL_tool_prepare_param_float(-77.99f);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[0]);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[1]);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(-97.61f);
-  BCL_tool_prepare_param_float(48.16f);
-  BCL_tool_prepare_param_float(-44.57f);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[0]);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[1]);
+  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_nanossoc_d60.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_nanossoc_d60.c
@@ -108,18 +108,18 @@ void BCL_load_power_off_nanossoc_d60(void)
 #ifndef SILS_FW // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[0]);
-  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[1]);
-  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[2]);
+  BCL_tool_prepare_param_float(-NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[0]);
+  BCL_tool_prepare_param_float(-NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[1]);
+  BCL_tool_prepare_param_float(-NANOSSOC_D60_PARAMETERS_mag_bias_compo_AOBC[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[0]);
-  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[1]);
-  BCL_tool_prepare_param_float(NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[2]);
+  BCL_tool_prepare_param_float(-NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[0]);
+  BCL_tool_prepare_param_float(-NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[1]);
+  BCL_tool_prepare_param_float(-NANOSSOC_D60_PARAMETERS_mag_bias_compo_EXT[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_oem7600.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_oem7600.c
@@ -15,6 +15,9 @@
 #include <src_user/Settings/System/EventHandlerRules/event_handler_rules.h>
 #include <src_user/Settings/System/event_logger_group.h>
 
+// Satellite parameters
+#include <src_user/Settings/SatelliteParameters/oem7600_parameters.h>
+
 void BCL_load_power_on_oem7600(void)
 {
   cycle_t bc_cycle = 1;
@@ -66,9 +69,9 @@ void BCL_load_power_on_oem7600(void)
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(223.03f);
-  BCL_tool_prepare_param_float(-126.81f);
-  BCL_tool_prepare_param_float(202.58f);
+  BCL_tool_prepare_param_float(OEM7600_PARAMETERS_mag_bias_compo[0]);
+  BCL_tool_prepare_param_float(OEM7600_PARAMETERS_mag_bias_compo[1]);
+  BCL_tool_prepare_param_float(OEM7600_PARAMETERS_mag_bias_compo[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
@@ -107,9 +110,9 @@ void BCL_load_power_off_oem7600(void)
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(-223.03f);
-  BCL_tool_prepare_param_float(126.81f);
-  BCL_tool_prepare_param_float(-202.58f);
+  BCL_tool_prepare_param_float(OEM7600_PARAMETERS_mag_bias_compo[0]);
+  BCL_tool_prepare_param_float(OEM7600_PARAMETERS_mag_bias_compo[1]);
+  BCL_tool_prepare_param_float(OEM7600_PARAMETERS_mag_bias_compo[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_oem7600.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_oem7600.c
@@ -101,18 +101,18 @@ void BCL_load_power_off_oem7600(void)
 #ifndef SILS_FW  // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(654.19f);
-  BCL_tool_prepare_param_float(374.0f);
-  BCL_tool_prepare_param_float(348.14f);
+  BCL_tool_prepare_param_float(-654.19f);
+  BCL_tool_prepare_param_float(-374.0f);
+  BCL_tool_prepare_param_float(-348.14f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(OEM7600_PARAMETERS_mag_bias_compo[0]);
-  BCL_tool_prepare_param_float(OEM7600_PARAMETERS_mag_bias_compo[1]);
-  BCL_tool_prepare_param_float(OEM7600_PARAMETERS_mag_bias_compo[2]);
+  BCL_tool_prepare_param_float(-OEM7600_PARAMETERS_mag_bias_compo[0]);
+  BCL_tool_prepare_param_float(-OEM7600_PARAMETERS_mag_bias_compo[1]);
+  BCL_tool_prepare_param_float(-OEM7600_PARAMETERS_mag_bias_compo[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_oem7600.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_oem7600.c
@@ -57,9 +57,9 @@ void BCL_load_power_on_oem7600(void)
 #ifndef SILS_FW  // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(119.31f);
-  BCL_tool_prepare_param_float(-81.50f);
-  BCL_tool_prepare_param_float(173.16f);
+  BCL_tool_prepare_param_float(654.19f);
+  BCL_tool_prepare_param_float(374.0f);
+  BCL_tool_prepare_param_float(348.14f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
@@ -98,9 +98,9 @@ void BCL_load_power_off_oem7600(void)
 #ifndef SILS_FW  // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(-119.31f);
-  BCL_tool_prepare_param_float(81.50f);
-  BCL_tool_prepare_param_float(-173.16f);
+  BCL_tool_prepare_param_float(654.19f);
+  BCL_tool_prepare_param_float(374.0f);
+  BCL_tool_prepare_param_float(348.14f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_sagitta.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_sagitta.c
@@ -15,6 +15,9 @@
 #include <src_user/Settings/System/EventHandlerRules/event_handler_rules.h>
 #include <src_user/Settings/System/event_logger_group.h>
 
+// Satellite Parameters
+#include <src_user/Settings/SatelliteParameters/sagitta_parameters.h>
+
 void BCL_load_power_on_sagitta(void)
 {
   cycle_t bc_cycle = OBCT_sec2cycle(1);
@@ -54,9 +57,9 @@ void BCL_load_power_on_sagitta(void)
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(55.22f);
-  BCL_tool_prepare_param_float(-36.99f);
-  BCL_tool_prepare_param_float(66.81f);
+  BCL_tool_prepare_param_float(SAGITTA_PARAMETERS_mag_bias_compo[0]);
+  BCL_tool_prepare_param_float(SAGITTA_PARAMETERS_mag_bias_compo[1]);
+  BCL_tool_prepare_param_float(SAGITTA_PARAMETERS_mag_bias_compo[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
@@ -109,9 +112,9 @@ void BCL_load_power_off_sagitta(void)
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(-55.22f);
-  BCL_tool_prepare_param_float(36.99f);
-  BCL_tool_prepare_param_float(-66.81f);
+  BCL_tool_prepare_param_float(SAGITTA_PARAMETERS_mag_bias_compo[0]);
+  BCL_tool_prepare_param_float(SAGITTA_PARAMETERS_mag_bias_compo[1]);
+  BCL_tool_prepare_param_float(SAGITTA_PARAMETERS_mag_bias_compo[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_sagitta.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_sagitta.c
@@ -45,9 +45,9 @@ void BCL_load_power_on_sagitta(void)
 #ifndef SILS_FW  // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(-2.34f);
-  BCL_tool_prepare_param_float(162.42f);
-  BCL_tool_prepare_param_float(-571.90f);
+  BCL_tool_prepare_param_float(445.64f);
+  BCL_tool_prepare_param_float(478.48f);
+  BCL_tool_prepare_param_float(-885.402f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
@@ -100,9 +100,9 @@ void BCL_load_power_off_sagitta(void)
 #ifndef SILS_FW  // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(2.34f);
-  BCL_tool_prepare_param_float(-162.42f);
-  BCL_tool_prepare_param_float(571.90f);
+  BCL_tool_prepare_param_float(445.64f);
+  BCL_tool_prepare_param_float(478.48f);
+  BCL_tool_prepare_param_float(-885.402f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_sagitta.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_sagitta.c
@@ -103,18 +103,18 @@ void BCL_load_power_off_sagitta(void)
 #ifndef SILS_FW  // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(445.64f);
-  BCL_tool_prepare_param_float(478.48f);
-  BCL_tool_prepare_param_float(-885.402f);
+  BCL_tool_prepare_param_float(-445.64f);
+  BCL_tool_prepare_param_float(-478.48f);
+  BCL_tool_prepare_param_float(885.402f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(SAGITTA_PARAMETERS_mag_bias_compo[0]);
-  BCL_tool_prepare_param_float(SAGITTA_PARAMETERS_mag_bias_compo[1]);
-  BCL_tool_prepare_param_float(SAGITTA_PARAMETERS_mag_bias_compo[2]);
+  BCL_tool_prepare_param_float(-SAGITTA_PARAMETERS_mag_bias_compo[0]);
+  BCL_tool_prepare_param_float(-SAGITTA_PARAMETERS_mag_bias_compo[1]);
+  BCL_tool_prepare_param_float(-SAGITTA_PARAMETERS_mag_bias_compo[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_stim210.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_stim210.c
@@ -44,18 +44,18 @@ void BCL_load_power_on_stim210(void)
 #ifndef SILS_FW // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(-5.51f);
-  BCL_tool_prepare_param_float(218.02f);
-  BCL_tool_prepare_param_float(-1095.40f);
+  BCL_tool_prepare_param_float(370.26f);
+  BCL_tool_prepare_param_float(224.98f);
+  BCL_tool_prepare_param_float(34.26f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(102.39f);
-  BCL_tool_prepare_param_float(-67.53f);
-  BCL_tool_prepare_param_float(131.76f);
+  BCL_tool_prepare_param_float(-15.45f);
+  BCL_tool_prepare_param_float(111.48f);
+  BCL_tool_prepare_param_float(-101.68f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_stim210.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_stim210.c
@@ -17,6 +17,9 @@
 #include <src_user/Settings/System/event_logger_group.h>
 #include <src_user/Applications/DriverInstances/di_stim210.h>
 
+// Satellite Parameters
+#include <src_user/Settings/SatelliteParameters/stim210_parameters.h>
+
 
 void BCL_load_power_on_stim210(void)
 {
@@ -53,9 +56,9 @@ void BCL_load_power_on_stim210(void)
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(-15.45f);
-  BCL_tool_prepare_param_float(111.48f);
-  BCL_tool_prepare_param_float(-101.68f);
+  BCL_tool_prepare_param_float(STIM210_PARAMETERS_mag_bias_compo[0]);
+  BCL_tool_prepare_param_float(STIM210_PARAMETERS_mag_bias_compo[1]);
+  BCL_tool_prepare_param_float(STIM210_PARAMETERS_mag_bias_compo[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
@@ -130,9 +133,9 @@ void BCL_load_power_off_stim210(void)
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(-102.39f);
-  BCL_tool_prepare_param_float(67.53f);
-  BCL_tool_prepare_param_float(-131.76f);
+  BCL_tool_prepare_param_float(STIM210_PARAMETERS_mag_bias_compo[0]);
+  BCL_tool_prepare_param_float(STIM210_PARAMETERS_mag_bias_compo[1]);
+  BCL_tool_prepare_param_float(STIM210_PARAMETERS_mag_bias_compo[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_stim210.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_stim210.c
@@ -124,18 +124,18 @@ void BCL_load_power_off_stim210(void)
 #ifndef SILS_FW  // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(370.26f);
-  BCL_tool_prepare_param_float(224.98f);
-  BCL_tool_prepare_param_float(34.26f);
+  BCL_tool_prepare_param_float(-370.26f);
+  BCL_tool_prepare_param_float(-224.98f);
+  BCL_tool_prepare_param_float(-34.26f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);
   bc_cycle++;
 
   BCL_tool_prepare_param_uint8(RM3100_IDX_EXTERNAL);
-  BCL_tool_prepare_param_float(STIM210_PARAMETERS_mag_bias_compo[0]);
-  BCL_tool_prepare_param_float(STIM210_PARAMETERS_mag_bias_compo[1]);
-  BCL_tool_prepare_param_float(STIM210_PARAMETERS_mag_bias_compo[2]);
+  BCL_tool_prepare_param_float(-STIM210_PARAMETERS_mag_bias_compo[0]);
+  BCL_tool_prepare_param_float(-STIM210_PARAMETERS_mag_bias_compo[1]);
+  BCL_tool_prepare_param_float(-STIM210_PARAMETERS_mag_bias_compo[2]);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);

--- a/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_stim210.c
+++ b/src/src_user/TlmCmd/NormalBlockCommandDefinition/nbc_stim210.c
@@ -121,9 +121,9 @@ void BCL_load_power_off_stim210(void)
 #ifndef SILS_FW  // TODO_L S2Eに電源ON/OFFでのバイアス変更機能を追加する
   // 磁気バイアス補正
   BCL_tool_prepare_param_uint8(RM3100_IDX_ON_AOBC);
-  BCL_tool_prepare_param_float(5.51f);
-  BCL_tool_prepare_param_float(-218.02f);
-  BCL_tool_prepare_param_float(1095.40f);
+  BCL_tool_prepare_param_float(370.26f);
+  BCL_tool_prepare_param_float(224.98f);
+  BCL_tool_prepare_param_float(34.26f);
   BCL_tool_prepare_param_uint8(1); // Add
 
   BCL_tool_register_cmd(bc_cycle, Cmd_CODE_DI_RM3100_SET_MAG_BIAS_COMPO_NT);


### PR DESCRIPTION
## Issue
- 関連する issue  https://github.com/ut-issl/c2a-aobc-onglaisat/issues/33

## 詳細
- oem,stim,sagittaのAOBC内磁気センサのバイアスの値をアップデート
- oem,stim,sagittaの外付け磁気センサ，ssのAOBC内と外付け磁気センサのバイアスの値を，satellite parametersで記載できるように変更

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 図や表で記述する

## 補足
NA

