### PR TITLE
WIP:Rangeテレメの追加

### DIFF
--- a/src/src_user/Applications/DriverInstances/di_oem7600.c
+++ b/src/src_user/Applications/DriverInstances/di_oem7600.c
@@ -191,15 +191,7 @@ CCP_CmdRet Cmd_DI_OEM7600_SET_TLM_CONTENTS(const CommonCmdPacket* packet)
 
   ENDIAN_memcpy(&oem7600_tlm_id, &(param[2]), sizeof(oem7600_tlm_id));
 
-  // range tlmの要求が来た時には、先にDSの設定が必要なので、ここで実施する
-  if (oem7600_tlm_id == OEM7600_TLM_ID_RANGE)
-  {
-    ret = OEM7600_start_rec_range_tlm(&oem7600_driver_[oem7600_id]);
-  }
-  else
-  {
-    ret = OEM7600_set_tlm_contents(&oem7600_driver_[oem7600_id], oem7600_tlm_id, tlm_out_interval_seconds);
-  }
+  ret = OEM7600_set_tlm_contents(&oem7600_driver_[oem7600_id], oem7600_tlm_id, tlm_out_interval_seconds);
 
   return DS_conv_cmd_err_to_ccp_cmd_ret(ret);
 }

--- a/src/src_user/Drivers/Aocs/oem7600.c
+++ b/src/src_user/Drivers/Aocs/oem7600.c
@@ -1025,15 +1025,6 @@ DS_CMD_ERR_CODE OEM7600_end_rec_range_tlm(OEM7600_Driver* oem7600_driver)
 
   oem7600_driver->info.range_tlm_status.is_receiving = 0;
 
-  // FIXME: rx_buffer が引数に必要だが, 意外と影響範囲が大きくて面倒くさい
-  // そもそもここで DS_init しているのはなぜ？必要ないなら消したい
-  // もしくは, rx_buffer を必要としないそれ以外の初期化を行う関数が欲しい
-#if 0
-  DS_init(&(oem7600_driver->driver.super),
-          &(oem7600_driver->driver.uart_config),
-          OEM7600_load_driver_super_init_settings_);
-#endif
-
   return DS_CMD_OK;
 }
 

--- a/src/src_user/Drivers/Aocs/oem7600.h
+++ b/src/src_user/Drivers/Aocs/oem7600.h
@@ -40,7 +40,7 @@ typedef enum
   OEM7600_TLM_ID_ANTENNA_VOLTAGE = 0x00000007,
   OEM7600_TLM_ID_SUPPLY_VOLTAGE  = 0x0000000F,
   // binary format系列
-  OEM7600_TLM_ID_RANGE            = 0x0000002B, // cmd/log manual 3.144項
+  OEM7600_TLM_ID_RANGE            = 0x0000002B, // cmd/log manual 3.144項 これはRangeのID
   OEM7600_TLM_ID_BEST_XYZ         = 0x000000F1, // cmd/log manual 3.21項
   OEM7600_TLM_ID_HARDWARE_MONITOR = 0x000003C3, // cmd/log manual 3.76項
   // 仕様書上はbinary/asciiで同一IDだが、CMD引数にIDを使うために、binary系列ID + 0x1000をascii系列として定義する
@@ -80,7 +80,9 @@ typedef struct
 
 /**
  * @struct OEM7600_RangeData
- * @brief OEM7600が提供するRANGEテレメデータ構造体
+ * @brief  OEM7600が提供するRANGEテレメデータ構造体
+ * @note   RANGEテレメとRANGEGPSL1テレメでデータ構造は同一
+ * @note   QZSSのPRMは193-202
  */
 typedef struct
 {

--- a/src/src_user/Drivers/Aocs/oem7600.h
+++ b/src/src_user/Drivers/Aocs/oem7600.h
@@ -13,7 +13,7 @@
 
 #define OEM7600_MAX_SAT_NUM_RANGE_STORE (12) //!< rangeテレメの格納対象とする同時可視最大衛星数
 
-#define DS_IF_RX_BUFFER_SIZE_OEM7600 (144)  //!< IF_RXのバッファサイズ
+#define DS_IF_RX_BUFFER_SIZE_OEM7600 (564)  //!< IF_RXのバッファサイズ
 
 /**
 * @enum  OEM7600_DATA_UPDATE_STATUS
@@ -140,14 +140,6 @@ typedef struct
   OEM7600_HardwareStatus hardware_status;
   OEM7600_RangeData range_tlm[OEM7600_MAX_SAT_NUM_RANGE_STORE];
   OEM7600_CRC_STATE crc_state;       //!< 受信したCRCが正しいか
-  // range_tlm受信用特殊パラメータ
-  struct oem7600
-  {
-    uint8_t is_receiving;             //!< flag to check whether the driver is under range tlm receiving or not
-    uint16_t received_tlm_len;        //!< length of the range data stored to the range tlm buffer
-    uint16_t expected_data_length;    //!< expected data length of range tlm sentence under receiving
-    uint16_t range_tlm_wait_counter;  //!< range tlmの受信処理call回数（閾値以上になった場合、range tlmの受信処理をリセット）
-  } range_tlm_status;
 } OEM7600_Info;
 
 /**
@@ -243,21 +235,5 @@ DS_CMD_ERR_CODE OEM7600_save_tlm_setting(OEM7600_Driver* oem7600_driver);
 DS_CMD_ERR_CODE OEM7600_set_uart_baudrate(OEM7600_Driver* oem7600_driver, const uint32_t baudrate,
                                           const OEM7600_UART_BAUDRATE_SET_DEVICE_ID device_id,
                                           DS_StreamRecBuffer* rx_buffer);
-
-
-/**
- * @brief  OEM7600のレンジテレメ取得開始コマンド送信処理
- * @param  oem7600: OEM7600_Driver構造体へのポインタ
- * @return DS_CMD_ERR_CODE
- */
-DS_CMD_ERR_CODE OEM7600_start_rec_range_tlm(OEM7600_Driver* oem7600_driver);
-
-
-/**
- * @brief  OEM7600のレンジテレメ取得終了コマンド送信処理
- * @param  oem7600: OEM7600_Driver構造体へのポインタ
- * @return DS_CMD_ERR_CODE
- */
-DS_CMD_ERR_CODE OEM7600_end_rec_range_tlm(OEM7600_Driver* oem7600_driver);
 
 #endif

--- a/src/src_user/Settings/DriverSuper/driver_super_params.h
+++ b/src/src_user/Settings/DriverSuper/driver_super_params.h
@@ -11,7 +11,7 @@
 #define DS_STREAM_MAX         (1)
 
 // TODO: 適切な値を考える
-// 最大であるSagittaのテレメに合わせて368byteとしている
-#define DS_IF_RX_BUFFER_SIZE  (368)
+// 最大であるOEM7600のRangeテレメに合わせて564byteとしている
+#define DS_IF_RX_BUFFER_SIZE  (564)
 
 #endif


### PR DESCRIPTION
## Issue
- https://github.com/ut-issl/c2a-aobc/issues/195

## 詳細

- 元のissueではGPSRのRangeテレメを取得するためのIFを追加する必要性があるという認識だったが，確認の結果，該当するテレメを取得するためのCMD/TLM IF自体は既に存在していた
- そのため，DriverSuperの受信バッファパラメータの変更し，分割受信処理を不要とする形に変更

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [x] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 改修後のSWについて，QL上でテレメカウンタが上がり続ける（＝TLMラインが正常に動作している）ことを確認
![image](https://github.com/ut-issl/c2a-aobc/assets/97158519/7402fd1e-9e15-4920-96a4-deeee6e7c680)

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
