### PR TITLE
Add BC_AC_OEM7600_UPDATE in TL of Bdot and RSP

### DIFF
--- a/src/src_user/Settings/Modes/TaskLists/tl_bdot.c
+++ b/src/src_user/Settings/Modes/TaskLists/tl_bdot.c
@@ -30,6 +30,9 @@ void BCL_load_bdot_mode(void)
   BCL_tool_register_app    (80, AR_APP_BDOT); // 1step以上
 
   BCL_tool_register_combine(90, BC_AC_MTQ_UPDATE); // 1step以上
+
+  // 基本使わないがユーザーが使いたい時に使えるように入れておく
+  BCL_tool_register_combine(92, BC_AC_OEM7600_UPDATE); // 1step以上
 }
 
 #pragma section

--- a/src/src_user/Settings/Modes/TaskLists/tl_rough_sun_pointing.c
+++ b/src/src_user/Settings/Modes/TaskLists/tl_rough_sun_pointing.c
@@ -35,6 +35,9 @@ void BCL_load_rough_sun_pointing_mode(void)
   BCL_tool_register_app    (85, AR_APP_SUN_POINTING); // 1step以上
 
   BCL_tool_register_combine(90, BC_AC_MTQ_UPDATE); // 1step以上
+
+  // 基本使わないがユーザーが使いたい時に使えるように入れておく
+  BCL_tool_register_combine(92, BC_AC_OEM7600_UPDATE); // 1step以上
 }
 
 #pragma section


### PR DESCRIPTION
## Issue
- #285 

## 詳細
ユーザーが使いたい場合に使えるよう，OEM7600のテレメ取得をBdotおよび太陽捕捉モードのタスクリストに追加した

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
