### PR TITLE
SSのテレメ異常EHのカウンタをSSごとに設定

### DIFF
--- a/src/src_user/Settings/SatelliteParameters/Sample/fdir_parameters.c
+++ b/src/src_user/Settings/SatelliteParameters/Sample/fdir_parameters.c
@@ -159,8 +159,12 @@ const uint32_t FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_rm3100_ms = 200
 const uint16_t FDIR_PARAMETERS_tlm_error_eh_switch_sensor_count_threshold_rm3100 = 10;
 const uint32_t FDIR_PARAMETERS_tlm_error_eh_switch_sensor_time_threshold_rm3100_ms = 0;
 // nanoSSOC D60
+// Prevents EHs from firing at the same time due to an anomaly on the common I2C bus
+const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_0 = 250;
+const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_1 = 260;
+const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_2 = 270;
+const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_3 = 280;
 // Use same value for all sun sensors (Users can also change the value with command for each sun sensors)
-const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60 = 250;
 const uint32_t FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms = 2000;
 // STIM210
 const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_stim210 = 100;

--- a/src/src_user/Settings/SatelliteParameters/fdir_parameters.h
+++ b/src/src_user/Settings/SatelliteParameters/fdir_parameters.h
@@ -161,8 +161,12 @@ extern const uint32_t FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_rm3100_m
 extern const uint16_t FDIR_PARAMETERS_tlm_error_eh_switch_sensor_count_threshold_rm3100;   //!< TLM error detection event handler switch sensor count threshold for RM3100 AOBC
 extern const uint32_t FDIR_PARAMETERS_tlm_error_eh_switch_sensor_time_threshold_rm3100_ms; //!< TLM error detection event handler switch sensor time threshold for RM3100 AOBC [ms]
 // nanoSSOC D60
+// Prevents EHs from firing at the same time due to an anomaly on the common I2C bus
+extern const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_0;    //!< TLM error detection event handler reset count threshold for nanoSSOC D60
+extern const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_1;    //!< TLM error detection event handler reset count threshold for nanoSSOC D60
+extern const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_2;    //!< TLM error detection event handler reset count threshold for nanoSSOC D60
+extern const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_3;    //!< TLM error detection event handler reset count threshold for nanoSSOC D60
 // Use same value for all sun sensors (Users can also change the value with command for each sun sensors)
-extern const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60;    //!< TLM error detection event handler reset count threshold for nanoSSOC D60
 extern const uint32_t FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms;  //!< TLM error detection event handler reset time threshold for nanoSSOC D60 [ms]
 // STIM210
 extern const uint16_t FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_stim210;           //!< TLM error detection event handler reset count threshold for STIM210

--- a/src/src_user/Settings/System/EventHandlerRules/event_handler_rule_tlmcmd.c
+++ b/src/src_user/Settings/System/EventHandlerRules/event_handler_rule_tlmcmd.c
@@ -346,7 +346,7 @@ void EH_load_rule_tlmcmd(void)
   settings.event.err_level = EL_ERROR_LEVEL_HIGH;
   settings.should_match_err_level = 1;
   settings.condition.type = EH_RESPONSE_CONDITION_CONTINUOUS;
-  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60;
+  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_1;
   settings.condition.time_threshold_ms = FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms;
   settings.deploy_bct_id = BC_RESET_NANOSSOC_D60;
   settings.is_active = 0;

--- a/src/src_user/Settings/System/EventHandlerRules/event_handler_rule_tlmcmd.c
+++ b/src/src_user/Settings/System/EventHandlerRules/event_handler_rule_tlmcmd.c
@@ -89,7 +89,7 @@ void EH_load_rule_tlmcmd(void)
   settings.event.err_level = EL_ERROR_LEVEL_HIGH;
   settings.should_match_err_level = 1;
   settings.condition.type = EH_RESPONSE_CONDITION_CONTINUOUS;
-  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60;
+  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_0;
   settings.condition.time_threshold_ms = FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms;
   settings.deploy_bct_id = BC_RESET_NANOSSOC_D60;
   settings.is_active = 0;
@@ -101,7 +101,7 @@ void EH_load_rule_tlmcmd(void)
   settings.event.err_level = EL_ERROR_LEVEL_HIGH;
   settings.should_match_err_level = 1;
   settings.condition.type = EH_RESPONSE_CONDITION_CONTINUOUS;
-  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60;
+  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_1;
   settings.condition.time_threshold_ms = FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms;
   settings.deploy_bct_id = BC_RESET_NANOSSOC_D60;
   settings.is_active = 0;
@@ -113,7 +113,7 @@ void EH_load_rule_tlmcmd(void)
   settings.event.err_level = EL_ERROR_LEVEL_HIGH;
   settings.should_match_err_level = 1;
   settings.condition.type = EH_RESPONSE_CONDITION_CONTINUOUS;
-  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60;
+  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_2;
   settings.condition.time_threshold_ms = FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms;
   settings.deploy_bct_id = BC_RESET_NANOSSOC_D60;
   settings.is_active = 0;
@@ -125,7 +125,7 @@ void EH_load_rule_tlmcmd(void)
   settings.event.err_level = EL_ERROR_LEVEL_HIGH;
   settings.should_match_err_level = 1;
   settings.condition.type = EH_RESPONSE_CONDITION_CONTINUOUS;
-  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60;
+  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_3;
   settings.condition.time_threshold_ms = FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms;
   settings.deploy_bct_id = BC_RESET_NANOSSOC_D60;
   settings.is_active = 0;
@@ -334,7 +334,7 @@ void EH_load_rule_tlmcmd(void)
   settings.event.err_level = EL_ERROR_LEVEL_HIGH;
   settings.should_match_err_level = 1;
   settings.condition.type = EH_RESPONSE_CONDITION_CONTINUOUS;
-  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60;
+  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_0;
   settings.condition.time_threshold_ms = FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms;
   settings.deploy_bct_id = BC_RESET_NANOSSOC_D60;
   settings.is_active = 0;
@@ -358,7 +358,7 @@ void EH_load_rule_tlmcmd(void)
   settings.event.err_level = EL_ERROR_LEVEL_HIGH;
   settings.should_match_err_level = 1;
   settings.condition.type = EH_RESPONSE_CONDITION_CONTINUOUS;
-  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60;
+  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_2;
   settings.condition.time_threshold_ms = FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms;
   settings.deploy_bct_id = BC_RESET_NANOSSOC_D60;
   settings.is_active = 0;
@@ -370,7 +370,7 @@ void EH_load_rule_tlmcmd(void)
   settings.event.err_level = EL_ERROR_LEVEL_HIGH;
   settings.should_match_err_level = 1;
   settings.condition.type = EH_RESPONSE_CONDITION_CONTINUOUS;
-  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60;
+  settings.condition.count_threshold = FDIR_PARAMETERS_tlm_error_eh_reset_count_threshold_nanossoc_d60_3;
   settings.condition.time_threshold_ms = FDIR_PARAMETERS_tlm_error_eh_reset_time_threshold_nanossoc_d60_ms;
   settings.deploy_bct_id = BC_RESET_NANOSSOC_D60;
   settings.is_active = 0;


### PR DESCRIPTION
## Issue
N/A

## 詳細
SS4つはI2Cバスを共有しているので、あるSSでテレメエラーが起きた時に、他のSSでもテレメエラーとなりうる。4つのEHが同時に発火して予期しない挙動となることを防ぐために、EH発火の条件をSS毎にずらす。

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
SILSで`event_handler_rule_tlmcmd.c`にて、各SSで別々のカウンタ閾値が設定されていることが確認できた。

## 補足
N/A

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
