### PR TITLE
fix MTQ controller behavior in ground test

### DIFF
--- a/src/src_user/Applications/UserDefined/AOCS/ExclusiveControl/magnetic_exclusive_control_timer.c
+++ b/src/src_user/Applications/UserDefined/AOCS/ExclusiveControl/magnetic_exclusive_control_timer.c
@@ -75,6 +75,12 @@ void APP_MECT_update_state_(void)
 {
   if (magnetic_exclusive_control_timer_.is_enable == APP_MECT_EXCLUSIVE_CONTROL_DISABLE)
   {
+    // 排他制御タイマーのコンフィグ変更を検知した場合、読み出す
+    if (magnetic_exclusive_control_timer_.is_config_buffered)
+    {
+      magnetic_exclusive_control_timer_.config = magnetic_exclusive_control_timer_.buffered_config;
+      magnetic_exclusive_control_timer_.is_config_buffered = false;
+    }
     // 排他制御が無効であるときは、磁気センサとMTQとの干渉を気にしないため、常にSTATE == CONTROLとする
     if (aocs_manager->magnetic_exclusive_control_timer_state != APP_AOCS_MANAGER_MAGNETIC_EXCLUSIVE_CONTROL_STATE_CONTROL)
     {

--- a/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c
+++ b/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c
@@ -22,6 +22,8 @@ const  MtqSeirenController* const mtq_seiren_controller = &mtq_seiren_controller
 static void APP_MTQ_SEIREN_CONTROLLER_init_(void);
 static void APP_MTQ_SEIREN_CONTROLLER_exec_(void);
 
+static const float APP_MTQ_SEIREN_CONTROLLER_kOutputRatioToZero_ = 1.0f / 200.0f; //!< 最大出力と比べてこの比より小さな出力はゼロとして扱う
+
 /**
  * @brief  MTQ出力時間計算関数
  * @param  void
@@ -148,7 +150,7 @@ static void APP_MTQ_SEIREN_CONTROLLER_convert_mag_moment_to_output_duration_(voi
                           magnetic_exclusive_control_timer->config.control_duration_ms));
 
       // 出力方向を計算
-      if (fabsf(mag_moment_mtq_Am2[idx]) < MATH_CONST_MACHINE_EPSILON)
+      if (fabsf(mag_moment_mtq_Am2[idx]) < mtq_seiren_driver[idx]->driver.max_mag_moment * APP_MTQ_SEIREN_CONTROLLER_kOutputRatioToZero_)
       {
         mtq_seiren_controller_.mtq_output_polarity[idx] = MTQ_SEIREN_NO_OUTPUT;
       }

--- a/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c
+++ b/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c
@@ -142,12 +142,24 @@ static void APP_MTQ_SEIREN_CONTROLLER_convert_mag_moment_to_output_duration_(voi
     }
     else
     {
+      // 出力時間を計算
       mtq_seiren_controller_.mtq_output_duration_ms[idx] =
         (uint16_t)(fabsf((mag_moment_mtq_Am2[idx] / mtq_seiren_driver[idx]->driver.max_mag_moment) *
                           magnetic_exclusive_control_timer->config.control_duration_ms));
 
-      mtq_seiren_controller_.mtq_output_polarity[idx] =
-        (mag_moment_mtq_Am2[idx] > 0.0f) ? MTQ_SEIREN_POLARITY_POSITIVE : MTQ_SEIREN_POLARITY_NEGATIVE;
+      // 出力方向を計算
+      if (fabsf(mag_moment_mtq_Am2[idx]) < MATH_CONST_MACHINE_EPSILON)
+      {
+        mtq_seiren_controller_.mtq_output_polarity[idx] = MTQ_SEIREN_NO_OUTPUT;
+      }
+      else if (mag_moment_mtq_Am2[idx] > 0.0f)
+      {
+        mtq_seiren_controller_.mtq_output_polarity[idx] = MTQ_SEIREN_POLARITY_POSITIVE;
+      }
+      else
+      { // mag_moment_mtq_Am2[idx] < 0.0f
+        mtq_seiren_controller_.mtq_output_polarity[idx] = MTQ_SEIREN_POLARITY_NEGATIVE;
+      }
 
       // テレメ出力用の計算
       mtq_seiren_controller_.mtq_output_duty[idx] =

--- a/src/src_user/Settings/Modes/TaskLists/Elements/tl_elem_drivers_update.c
+++ b/src/src_user/Settings/Modes/TaskLists/Elements/tl_elem_drivers_update.c
@@ -20,7 +20,7 @@ void BCL_load_drivers_update_initial()
   BCL_tool_register_app(4, AR_NOP);
   BCL_tool_register_app(5, AR_NOP);
   BCL_tool_register_app(6, AR_DI_MPU9250);
-  BCL_tool_register_app(7, AR_DI_MTQ_SEIREN);
+  BCL_tool_register_app(7, AR_DI_NOP);
   BCL_tool_register_app(8, AR_NOP);
   BCL_tool_register_app(9, AR_NOP);
 }

--- a/src/src_user/Settings/Modes/TaskLists/Elements/tl_elem_drivers_update.c
+++ b/src/src_user/Settings/Modes/TaskLists/Elements/tl_elem_drivers_update.c
@@ -20,7 +20,7 @@ void BCL_load_drivers_update_initial()
   BCL_tool_register_app(4, AR_NOP);
   BCL_tool_register_app(5, AR_NOP);
   BCL_tool_register_app(6, AR_DI_MPU9250);
-  BCL_tool_register_app(7, AR_DI_NOP);
+  BCL_tool_register_app(7, AR_NOP);
   BCL_tool_register_app(8, AR_NOP);
   BCL_tool_register_app(9, AR_NOP);
 }

--- a/src/src_user/Settings/Modes/TaskLists/tl_initial.c
+++ b/src/src_user/Settings/Modes/TaskLists/tl_initial.c
@@ -23,7 +23,7 @@ void BCL_load_initial_mode(void)
   BCL_tool_register_combine(36, BC_AC_RM3100_UPDATE);  // 4step以上
   BCL_tool_register_combine(41, BC_AC_STIM210_UPDATE); // 1step以上
 
-  BCL_tool_register_app    (45, AR_DI_MTQ_SEIREN);     // 1step以上, MTQ駆動時間カウンタを20 [Hz]周期にするため入れている
+  BCL_tool_register_combine(45, BC_AC_MTQ_UPDATE);     // 1step以上, MTQ駆動時間カウンタを20 [Hz]周期にするため入れている
 
   BCL_tool_register_combine(47, BC_AC_SUN_VECTOR_UPDATE);   // 合計4step以上必要ある？
   BCL_tool_register_combine(51, BC_AC_INERTIAL_REF_UPDATE); // 11step以上
@@ -36,7 +36,7 @@ void BCL_load_initial_mode(void)
 
   // BCL_tool_register_app   (90, AR_APP_MODULE_TEST_BENCH);  // 打ち上げ時は必ずコメントアウトする
 
-  BCL_tool_register_app    (95, AR_DI_MTQ_SEIREN); // 1step以上
+  BCL_tool_register_combine(95, BC_AC_MTQ_UPDATE); // 1step以上
 }
 
 #pragma section


### PR DESCRIPTION
## Issue
- resolve #268 

## 詳細
- MTQの電気試験を実施していた際に気づいた挙動を修正している。修正ごとにcommitを分けており、それぞれの詳しい内容は以下のとおり。

### initial modeでMTQ DIが呼ばれないように修正

- 該当commit： b1fe15768eeadcb88a4cd3cb05aaf1e6f15df467
- 起きていた問題： #261 の改修により、 MTQドライバおよびDIは単なるGPIO操作アプリとなるように仕様変更されたため、 `update` 関数は定義せず以下のように `create_app` の際にNULLを呼ぶようにしていた。しかし、initial modeにおいてはtasklistでMTQ DIが呼ばれてしまっていた（これによりinitial modeで3-4アノマリが出ていた）。

https://github.com/ut-issl/c2a-aobc/blob/f30cf06913b3155b938499c7c72e2651d2d6c779/src/src_user/Applications/DriverInstances/di_mtq_seiren.c#L32-L35

- 本commitでの対処： tasklist でMTQ DIが呼ばれないようにし、代わりにMTQ疑似PWM機能を提供するBCである `BC_AC_MTQ_UPDATE` を入れた。

### 制御時間コンフィグを排他制御が無効の場合でも読み出すように修正

- 該当commit： 1f81f3565fb9d98464ef01ce7c1f11b626bfcd8e
- 起きていた問題： 磁気制御時間に関するコンフィグ（観測時間・制御時間・消磁時間の長さ）は以下のように `aocs_manager->magnetic_exclusive_control_timer_state == APP_AOCS_MANAGER_MAGNETIC_EXCLUSIVE_CONTROL_STATE_STANDBY` の場合にしか更新されないようになっており、排他制御が無効の場合だとコンフィグが更新されないようになってしまっていた。これにより、地上試験のために排他制御は無効にしたいが、疑似PWMの周期を伸ばしたいときにコンフィグを更新できなかった。

https://github.com/ut-issl/c2a-aobc/blob/f30cf06913b3155b938499c7c72e2651d2d6c779/src/src_user/Applications/UserDefined/AOCS/ExclusiveControl/magnetic_exclusive_control_timer.c#L108-L113

- 本commitでの対処： 排他制御が無効の状態でコンフィグが更新された場合もコンフィグを読み出すように修正した。

### 目標MTQ出力がゼロの場合、明示的にゼロ出力となるように指定

- 該当commit： fa1f946800c64e743b3cecd027ab917766e871bc
- 起きていた問題： 目標出力磁気モーメントから出力極性を計算する際、以下のような判定式になっており、目標出力磁気モーメントがゼロのとき一瞬だけMTQから負の磁気モーメントが出るようになってしまっていた。

https://github.com/ut-issl/c2a-aobc/blob/f30cf06913b3155b938499c7c72e2651d2d6c779/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c#L149-L150

- 本commitでの対処： 目標出力磁気モーメントがゼロの際は、出力極性もゼロ出力になるように明示的に指定した。

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [x] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [x] 実機でアルゴリズムが想定通りに動いた
- [x] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク

以下のコマンド列が正しく通ることを実機で確認済み

![image](https://github.com/ut-issl/c2a-aobc/assets/93800108/6599ff68-4453-48a7-aca9-53618669fa4f)

![image](https://github.com/ut-issl/c2a-aobc/assets/93800108/a8ef68b1-b48e-4ba5-b05d-548e79c174f2)

![image](https://github.com/ut-issl/c2a-aobc/assets/93800108/a6143047-1699-4f73-89e8-6f41979146c2)

![image](https://github.com/ut-issl/c2a-aobc/assets/93800108/d9aec4ea-bc8f-4372-b37e-60b0f89c4cb6)


## 補足
何かあれば書く。なければ`NA`とする。

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
