### PR TITLE
remove tl_gpsr_range_observe.c from vcxproj

### DIFF
--- a/C2A_AOBC.vcxproj
+++ b/C2A_AOBC.vcxproj
@@ -304,7 +304,6 @@
     <ClCompile Include="src\src_user\Settings\Modes\TaskLists\tl_rough_sun_pointing.c" />
     <ClCompile Include="src\src_user\Settings\Modes\TaskLists\tl_rough_three_axis.c" />
     <ClCompile Include="src\src_user\Settings\Modes\TaskLists\tl_rough_three_axis_rw.c" />
-    <ClCompile Include="src\src_user\Settings\Modes\TaskLists\tl_gpsr_range_observe.c" />
     <ClCompile Include="src\src_user\Settings\Modes\Transitions\sl_bdot.c" />
     <ClCompile Include="src\src_user\Settings\Modes\Transitions\sl_fine_three_axis.c" />
     <ClCompile Include="src\src_user\Settings\Modes\Transitions\sl_initial.c" />


### PR DESCRIPTION
## Issue
- NA

## 詳細
vcxprojファイルから，削除済みソースファイル`tl_gpsr_range_obsrve.c`を削除  

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- NA

## 補足
NA


