### PR TITLE
fix reset timing for torque integration in MTQ controller

### DIFF
--- a/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c
+++ b/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c
@@ -111,6 +111,8 @@ void APP_MTQ_SEIREN_CONTROLLER_exec_(void)
     {
       MTQ_SEIREN_output(mtq_seiren_driver[idx], MTQ_SEIREN_NO_OUTPUT);
     }
+    // 消磁中も積分を続ける
+    mtq_seiren_controller_.integrator_status = MTQ_SEIREN_CONTROLLER_TORQUE_IS_INTEGRATING;
     break;
   default:
     // NOT REACHED

--- a/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c
+++ b/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c
@@ -70,6 +70,7 @@ void APP_MTQ_SEIREN_CONTROLLER_init_(void)
   mtq_seiren_controller_.previous_torque_integration_obc_time = TMGR_get_master_clock();
   mtq_seiren_controller_.cross_product_error = CROSS_PRODUCT_CONTROL_ERROR_OK;
   mtq_seiren_controller_.cross_product_error_ratio = 0.0f;
+  mtq_seiren_controller_.integrator_status = MTQ_SEIREN_CONTROLLER_TORQUE_IS_INTEGRATING;
 }
 
 void APP_MTQ_SEIREN_CONTROLLER_exec_(void)
@@ -81,10 +82,16 @@ void APP_MTQ_SEIREN_CONTROLLER_exec_(void)
   case APP_AOCS_MANAGER_MAGNETIC_EXCLUSIVE_CONTROL_STATE_OBSERVE:
     // 次にMTQを出力するとき、何秒間電流を流すかを決める
     APP_MTQ_SEIREN_CONTROLLER_convert_mag_moment_to_output_duration_();
-    // 次回の出力を決めたら、トルク積分値をリセットする
-    APP_MTQ_SEIREN_CONTROLLER_reset_integrated_torque_();
+    // 指令トルクの積分は完了
+    mtq_seiren_controller_.integrator_status = MTQ_SEIREN_CONTROLLER_TORQUE_INTEGRATION_COMPLETED;
     break;
   case APP_AOCS_MANAGER_MAGNETIC_EXCLUSIVE_CONTROL_STATE_CONTROL:
+    if (mtq_seiren_controller_.integrator_status == MTQ_SEIREN_CONTROLLER_TORQUE_INTEGRATION_COMPLETED)
+    {
+      // 指令トルク積分値をリセットし、次のトルク指令に備えて積分をリスタートする
+      APP_MTQ_SEIREN_CONTROLLER_reset_integrated_torque_();
+      mtq_seiren_controller_.integrator_status = MTQ_SEIREN_CONTROLLER_TORQUE_IS_INTEGRATING;
+    }
     // APP_AOCS_MANAGER_MAGNETIC_EXCLUSIVE_CONTROL_STATE_OBSERVEのケースで計算していた出力時間の分だけMTQを出力する
     for (size_t idx = 0; idx < MTQ_SEIREN_IDX_MAX; idx++)
     {

--- a/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.h
+++ b/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.h
@@ -13,6 +13,17 @@
 #include <src_user/Applications/DriverInstances/di_mtq_seiren.h>
 
 /**
+ * @struct MTQ_SEIREN_CONTROLLER_TORQUE_INTEGRATOR_STATUS
+ * @brief  指令トルクの積分状態
+ * @note   int8_tを想定
+ */
+typedef enum
+{
+  MTQ_SEIREN_CONTROLLER_TORQUE_IS_INTEGRATING = 0,   //!< 積分中
+  MTQ_SEIREN_CONTROLLER_TORQUE_INTEGRATION_COMPLETED //!< 積分完了
+} MTQ_SEIREN_CONTROLLER_TORQUE_INTEGRATOR_STATUS;
+
+/**
  * @struct MtqSeirenController
  * @brief  MTQ_SEIRENの制御に必要な情報を管理する構造体
  */
@@ -23,8 +34,9 @@ typedef struct
   int8_t mtq_output_duty[MTQ_SEIREN_IDX_MAX];                  //!< 極性と出力時間から計算され、テレメに出力するためのMTQ出力duty比 [-100, +100] （単位：％）
 
   // 消磁中に更新された指令トルクに関する積分関連パラメータ
-  float integrated_torque_Nms[PHYSICAL_CONST_THREE_DIM]; //!< 消磁中に更新された指令トルクを積分して角運動量指令に換算するためのバッファ [Nms]
-  ObcTime  previous_torque_integration_obc_time;         //!< 前回積分した時間
+  float integrated_torque_Nms[PHYSICAL_CONST_THREE_DIM];             //!< 消磁中に更新された指令トルクを積分して角運動量指令に換算するためのバッファ [Nms]
+  MTQ_SEIREN_CONTROLLER_TORQUE_INTEGRATOR_STATUS integrator_status;  //!< 指令トルクの積分状態
+  ObcTime  previous_torque_integration_obc_time;                     //!< 前回積分した時間
 
   CROSS_PRODUCT_CONTROL_ERROR cross_product_error;    //!< CrossProductの実行エラー記録 (TODO_L: 残すか要検討，デバッグ用)
   float cross_product_error_ratio;


### PR DESCRIPTION
## Issue
- N/A

## 詳細

# 起こっていた問題

これまでの `mtq_seiren_controller.c` の実装では、`APP_AOCS_MANAGER_MAGNETIC_EXCLUSIVE_CONTROL_STATE_OBSERVE` のケースに複数回連続で入ると、「トルクから出力磁気モーメントを計算 --> 指令トルク積分値をリセット」というサイクルを複数回繰り返してしまい、指令トルクがリセットされた状態で出力磁気モーメントを再計算されてしまうという問題があった。

https://github.com/ut-issl/c2a-aobc/blob/cfda144b96f5034babcbf8eb77a18960940f0132/src/src_user/Applications/UserDefined/AOCS/HardwareDependent/ActuatorControllers/mtq_seiren_controller.c#L79-L86

# 本PRにおける対応

`APP_AOCS_MANAGER_MAGNETIC_EXCLUSIVE_CONTROL_STATE_OBSERVE`  の間は指令トルク積分値をリセットせず、`APP_AOCS_MANAGER_MAGNETIC_EXCLUSIVE_CONTROL_STATE_CONTROL` に入った初回で指令トルク積分値がリセットされるように変更した。こうすることで、出力磁気モーメントを計算するときには 積分値がリセットされないことを保証している。

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 図や表で記述する

## 補足
何かあれば書く。なければ`NA`とする。

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
