### PR TITLE
fix Bdot tasklist to handle MTQ output error in Bdot mode

### DIFF
--- a/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/bdot.c
+++ b/src/src_user/Applications/UserDefined/AOCS/AttitudeControl/bdot.c
@@ -12,6 +12,8 @@
 #include <src_user/Library/math_constants.h>
 #include <src_user/Applications/UserDefined/AOCS/aocs_manager.h>
 #include <src_user/Applications/DriverInstances/di_mtq_seiren.h>
+#include <src_user/Applications/UserDefined/AOCS/ExclusiveControl/magnetic_exclusive_control_timer.h>
+
 
 // Satellite parameters
 #include <src_user/Settings/SatelliteParameters/attitude_control_parameters.h>
@@ -68,6 +70,8 @@ static void APP_BDOT_init_(void)
 
 void APP_BDOT_exec_(void)
 {
+  // 排他制御モードが OBSERVE でなければ、磁気センサの読みはMTQの出力に汚されているのでBdotも使えない
+  if (aocs_manager->magnetic_exclusive_control_timer_state != APP_AOCS_MANAGER_MAGNETIC_EXCLUSIVE_CONTROL_STATE_OBSERVE) return;
   // 磁気モーメント目標値を計算し、AOCS MANAGERにセットする
   APP_BDOT_calculate_target_mtq_output_();
   // 実際にMTQの出力を行うのは、MTQ_SEIREN_CONTROLLERの中になる

--- a/src/src_user/Settings/Modes/TaskLists/tl_bdot.c
+++ b/src/src_user/Settings/Modes/TaskLists/tl_bdot.c
@@ -22,12 +22,16 @@ void BCL_load_bdot_mode(void)
   // Bdotアプリ
   BCL_tool_register_combine(40, BC_AC_MTQ_UPDATE);  // 1step以上, MTQ駆動時間カウンタを20 [Hz]周期にするため入れている
 
-  BCL_tool_register_combine(45, BC_AC_RM3100_UPDATE); // 4step以上
+  BCL_tool_register_app    (45, AR_DI_MPU9250);         // 3step以上
+  BCL_tool_register_app    (50, AR_APP_MPU9250_FILTER); // 1step以上
+
+  BCL_tool_register_combine(55, BC_AC_RM3100_UPDATE); // 4step以上
 
   BCL_tool_register_app    (60, AR_APP_GYRO_SELECTOR); // 1step以上
 
-
   BCL_tool_register_app    (80, AR_APP_BDOT); // 1step以上
+
+  BCL_tool_register_app    (85, AR_APP_AOCS_MTQ_SEIREN_CONTROLLER); // 排他制御モードがOBSERVEのうちに目標出力計算するために入れている
 
   BCL_tool_register_combine(90, BC_AC_MTQ_UPDATE); // 1step以上
 


### PR DESCRIPTION
## Issue
- #312 

## 詳細

- Bdotアプリの実行タイミングと、排他磁気制御タイマーなど磁気関連アプリの実行タイミング次第でMTQの出力が出なくなってしまうことがわかったので、その対症療法的な修正になります。

## 背景

- #312 に詳しく記載しています。

### Bdotアプリ・排他制御タイマー・MTQコントローラーアプリの実行順序の調整
- 起きている問題の本質は、Bdotアプリで目標出力トルクを計算した後、MTQコントローラーでMTQ DIに指示する出力時間を計算する前にMTQ排他制御タイマーが入ってしまうことで、排他制御ステートが `CONTROL` に切り替わってしまう場合があることにありました。
  - 出力時間の計算は排他制御ステートが `OBSERVE` であるときに実行されるようになっていて、Bdotアプリの計算後出力時間が計算されないままMTQ制御に入ってしまう、という問題になります。
  - したがって、Bdotアプリが実行された後、排他制御タイマーが実行される前にMTQコントローラーの実行を差し込み、`OBSERVE` モード中に確実に Bdotの計算結果が MTQコントローラーに引き渡されるように調整しています。

### Bdotの時間微分計算を `OBSERVE` モードのときに制限
- また、Bdotアプリで磁気微分のΔtを1秒程度確保したいというモチベーションがあり（0.1秒程度だと磁気センサの読みの差分がホワイトノイズに埋もれてしまう可能性がある）、そのための改修も実施しています。
  - 素朴に微分時間を1秒に伸ばすだけだと、排他磁気制御ステートが `OBSERVE` でない時などに微分が実行されてしまうことがあり、微分値が信頼できなくなるのに加え、`OBSERVE` モードのときに計算結果をMTQコントローラに引き渡すこともできなくなってしまうという問題があります。
  - したがって、今回の改修でBdotの時間微分計算を `OBSERVE` モードのときに制限するようにしています。

### MPU9250のDIおよびフィルタを、「排他磁気制御タイマーの後かつ磁気センサセレクタの前」に入れた

- BdotタスクリストでMPU9250を使うとMTQ出力が出なくなるという問題もあり、これはタスクリスト上でMPU9250 DI・フィルタの実行タイミングに問題があることが判明しました。
- これは、磁気センサフィルタが `OBSERVE` モードでのみ機能する（スパイクフィルタを含むため）ようにしていることに由来しています。
- これまでのtasklistだと、MPU9250フィルタが `OBSERVE` モードで実行されたあと、排他磁気制御タイマーが `CONTROL` に切り替わってから Bdotアプリ・MTQコントローラに引き渡されるようなことがあり、これだとBdotアプリの計算結果を見ることなくMTQ制御に入ってしまうことになります。
- したがって、このPRでMPU9250もRM3100と同じように排他制御タイマーが切り替わってからDIとフィルタが実行されるようになっています。

### まとめ

Bdotアプリの理想的な実行順序は、以下のようになります。

1. 排他制御タイマーで `OBSERVE` モードに入る
2. 磁気センサDI・フィルタ・セレクタを実行する
3. Bdotアプリで目標出力トルクを計算する
4. MTQコントローラーでMTQ DIに指示する出力時間を計算する
5. 排他制御タイマーが `CONTROL` モードに入る

上記の2. ~ 4. が1. と5. の外で実行されてしまうと、その途中で排他制御タイマーのステートが切り替わってしまうことがあり、Bdot出力の計算を見ることなくMTQ出力が始まってしまうことが根本的な原因でした。今回のPRでは、上の順序が守られるようにタスクリストの実行順序を調整しています。


## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク

MPU9250でBdotできるようになった。

![image](https://github.com/ut-issl/c2a-aobc/assets/93800108/7c8ef2d0-f800-4e72-b8a9-79ee92728764)

- また、これまで数十回 initial modeからテキトウなタイミングでBdotに遷移させているが、MTQ出力に失敗するようなケースは一度もなくなった。

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
