### PR TITLE
Fix hard coded RW I2C address

### DIFF
--- a/src/src_user/IfWrapper/Sils/i2c_sils.c
+++ b/src/src_user/IfWrapper/Sils/i2c_sils.c
@@ -5,6 +5,7 @@
  */
 
 #include <src_core/IfWrapper/i2c.h>
+#include <src_user/Settings/port_config.h>
 
 int OBC_C2A_I2cWriteCommand (int port_id, const unsigned char i2c_addr, const unsigned char* data, const unsigned char len);
 int OBC_C2A_I2cWriteRegister(int port_id, const unsigned char i2c_addr, const unsigned char* data, const unsigned char len);
@@ -43,7 +44,9 @@ int I2C_tx(void* my_i2c_v, void* data_v, int data_size)
   // RW0003専用特殊処理 FIXME: 別の場所に置き換える->S2E側の大きな改修が必要なので少し後回し
   if (my_i2c->ch == 1)
   {
-    if (my_i2c->device_address == 0x11 || my_i2c->device_address == 0x12 || my_i2c->device_address == 0x13)
+    if (my_i2c->device_address == I2C_DEVICE_ADDR_RW_X ||
+        my_i2c->device_address == I2C_DEVICE_ADDR_RW_Y ||
+        my_i2c->device_address == I2C_DEVICE_ADDR_RW_Z)
     {
       if (my_i2c->stop_flag == 0)
       {


### PR DESCRIPTION
## Issue
NA

## 詳細
RW I2Cアドレスを自由に設定できるようにした時に、ハードコーディングの部分を修正し忘れていたので、修正した。

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った -> SILSの時だけビルドされるので関係無し。

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた  -> SILSの時だけビルドされるので関係無し。
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
別PJユーザー部で動作確認済み

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
