### PR TITLE
Add BC_AC_STIM210_UPDATE in Rough Sun Pointing TL

### DIFF
--- a/src/src_user/Settings/Modes/TaskLists/tl_rough_sun_pointing.c
+++ b/src/src_user/Settings/Modes/TaskLists/tl_rough_sun_pointing.c
@@ -24,6 +24,9 @@ void BCL_load_rough_sun_pointing_mode(void)
 
   BCL_tool_register_combine(45, BC_AC_RM3100_UPDATE); // 4step以上
 
+  // 基本使わないがユーザーが使いたい時に使えるように入れておく
+  BCL_tool_register_combine(55, BC_AC_STIM210_UPDATE); // 1step以上
+
   BCL_tool_register_app    (60, AR_APP_GYRO_SELECTOR); // 1step以上
   BCL_tool_register_combine(65, BC_AC_SUN_VECTOR_UPDATE); // 合計4step以上
 


### PR DESCRIPTION
## Issue
- NA

## 詳細
ユーザーが太陽捕捉モードでSTIM210を使いたい場合に使えるよう，タスクリストに追加した。

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [ ] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
後ほど実機で検証する。

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
