### PR TITLE
Add NaN assertion

### DIFF
--- a/src/src_user/Library/SignalProcess/spike_filter.c
+++ b/src/src_user/Library/SignalProcess/spike_filter.c
@@ -66,6 +66,14 @@ C2A_MATH_ERROR SPIKE_FILTER_calc_output_uint32(SpikeFilter* filter, uint32_t* ou
 
 C2A_MATH_ERROR SPIKE_FILTER_calc_output_double(SpikeFilter* filter, double* output, const double input)
 {
+  // NAN確認
+  C2A_MATH_ERROR ret = C2A_MATH_check_nan_inf_double(input);
+  if (ret != C2A_MATH_ERROR_OK)
+  {
+    *output = filter->last_accept_val_;
+    return C2A_MATH_ERROR_NAN;
+  }
+
   C2A_MATH_ERROR judgement_result = C2A_MATH_ERROR_OK;
 
   double diff = input - filter->last_accept_val_;

--- a/src/src_user/Library/SignalProcess/z_filter.c
+++ b/src/src_user/Library/SignalProcess/z_filter.c
@@ -8,7 +8,7 @@
 
 #include <math.h>
 #include <src_user/Library/math_constants.h>
-
+#include <src_core/System/EventManager/event_logger.h>
 
 //!< bilinear transformation
 static C2A_MATH_ERROR Z_FILTER_bilinear_trans_(ZFilter* filter,
@@ -161,7 +161,8 @@ double Z_FILTER_calc_output_double(ZFilter* filter, const double input)
   C2A_MATH_ERROR ret = C2A_MATH_check_nan_inf_double(input);
   if (ret != C2A_MATH_ERROR_OK)
   {
-    // TODO: Add Event Logger
+    // TODO: IDは現状テキトウな値なので、修正する(今はアプリIDと被らない大きな値にしている。)
+    EL_record_event(EL_GROUP_CALCULATION_ERROR, 201, EL_ERROR_LEVEL_LOW, (uint32_t)ret);
     return filter->output_previous[0];
   }
 

--- a/src/src_user/Library/SignalProcess/z_filter.c
+++ b/src/src_user/Library/SignalProcess/z_filter.c
@@ -157,6 +157,14 @@ float Z_FILTER_calc_output(ZFilter* filter, const float input)
 
 double Z_FILTER_calc_output_double(ZFilter* filter, const double input)
 {
+  // NAN確認
+  C2A_MATH_ERROR ret = C2A_MATH_check_nan_inf_double(input);
+  if (ret != C2A_MATH_ERROR_OK)
+  {
+    // TODO: Add Event Logger
+    return 0.0;
+  }
+
   double output_d = input;
 
   switch (filter->order)

--- a/src/src_user/Library/SignalProcess/z_filter.c
+++ b/src/src_user/Library/SignalProcess/z_filter.c
@@ -162,7 +162,7 @@ double Z_FILTER_calc_output_double(ZFilter* filter, const double input)
   if (ret != C2A_MATH_ERROR_OK)
   {
     // TODO: Add Event Logger
-    return 0.0;
+    return filter->output_previous[0];
   }
 
   double output_d = input;

--- a/src/src_user/Library/pid_control.c
+++ b/src/src_user/Library/pid_control.c
@@ -76,6 +76,15 @@ void PID_CONTROL_calc_output(PidControl* pid_control, const float error)
                                  pid_control->gains.d_gain * pid_control->d_error;
   pid_control->pre_error = pid_control->error;
 
+  // NAN確認
+  C2A_MATH_ERROR ret = C2A_MATH_check_nan_inf(pid_control->control_output);
+  if (ret != C2A_MATH_ERROR_OK)
+  {
+    pid_control->control_output = 0.0f;
+    PID_CONTROL_reset_integral_error(pid_control);
+    pid_control->pre_error = 0.0f;
+  }
+
   return;
 }
 

--- a/src/src_user/Library/pid_control.c
+++ b/src/src_user/Library/pid_control.c
@@ -9,6 +9,7 @@
 #include <math.h>
 
 #include <src_core/System/TimeManager/time_manager.h>
+#include <src_core/System/EventManager/event_logger.h>
 
 #include "math_constants.h"
 
@@ -83,7 +84,8 @@ void PID_CONTROL_calc_output(PidControl* pid_control, const float error)
     pid_control->control_output = 0.0f;
     PID_CONTROL_reset_integral_error(pid_control);
     pid_control->pre_error = 0.0f;
-    // TODO: Add Event Logger
+    // TODO: IDは現状テキトウな値なので、修正する(今はアプリIDと被らない大きな値にしている。)
+    EL_record_event(EL_GROUP_CALCULATION_ERROR, 200, EL_ERROR_LEVEL_LOW, (uint32_t)ret);
   }
 
   return;

--- a/src/src_user/Library/pid_control.c
+++ b/src/src_user/Library/pid_control.c
@@ -83,6 +83,7 @@ void PID_CONTROL_calc_output(PidControl* pid_control, const float error)
     pid_control->control_output = 0.0f;
     PID_CONTROL_reset_integral_error(pid_control);
     pid_control->pre_error = 0.0f;
+    // TODO: Add Event Logger
   }
 
   return;


### PR DESCRIPTION
## Issue
現状これを入れないと問題が出るというわけではないが、過去のバグを含め包括的にこの手の現象に対応するため。

## 詳細
数値計算上のNaNを回避するためにAssertionを入れた。特に過去のデータを引きずりエラーが継続しやすい次の箇所に入れた
- PID制御
- フィルター系

## 検証結果
### ビルドチェック (どちらもチェック)
- [x] SILSでのビルドチェックに通った(CIで確認)
- [ ] vMicroでのビルドチェックに通った

### 動作確認チェック (いずれかをチェック)
- [x] SILSでアルゴリズムが想定通りに動いた
- [ ] 実機でアルゴリズムが想定通りに動いた
- [ ] (テレコマ試験の場合)コマンドファイルを使った試験をパスした

### 試験結果詳細記述場所 or 詳細ログ保存場所へのリンク
- 現時点で動かしてこのAssertionに引っ掛かることはなく、修正前後で制御結果などは変わりえない

## 補足
NA

<!--
## 注意
- 必ず`Reviewers` を設定すること
  - AOCSメンテナメンバー
- `Assignees` を自分自身に割り当てること
- `Projects`として`6U AOCS team (private)`を設定する
  - `Status`を`Waiting Review`に設定する
- 必ず`priority` ラベルを付けること
  - high: 試験などの関係ですぐさまレビューしてほしい
  - middle: 通常これ
  - low: ゆっくりで良いもの
- 必ず`update`ラベルをつけること
  - major: 後方互換性なしのI/F変更
  - minor: 後方互換性ありのI/F変更
  - patch: I/F変更なし
- テンプレート記述は残さず、削除したり`NA`と書き換えたりする
-->
